### PR TITLE
Allow Decypharr to be used

### DIFF
--- a/utils/decypharr_settings.py
+++ b/utils/decypharr_settings.py
@@ -78,7 +78,7 @@ def patch_decypharr_config():
             final_config["allowed_file_types"] = config_data.get(
                 "allowed_file_types", []
             )
-            final_config["use_auth"] = config_data.get("use_auth", True)
+            final_config["use_auth"] = config_data.get("use_auth", False)
 
             with open(config_path, "w") as file:
                 json.dump(final_config, file, indent=4)


### PR DESCRIPTION
Making this value true by default will cause the user to be unable to login, and no value is set for login credentials during onboarding.

The user can set their username and password afterwards in the Decypharr GUI, modifying the configuration as desired once set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration to disable authentication when extending settings. The “use_auth” option now defaults to off unless explicitly enabled.
  * No other behavior or control flow changes; configuration generation and saving remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->