### PR TITLE
fix: atomic writes for dumb_config.json to prevent corruption on shutdown

### DIFF
--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -47,7 +47,7 @@ class ConfigManager:
                 os.fchmod(fd, st.st_mode & 0o777)
                 if hasattr(os, "fchown"):
                     os.fchown(fd, st.st_uid, st.st_gid)
-            except (FileNotFoundError, PermissionError):
+            except OSError:
                 pass
             with os.fdopen(fd, "w") as tmp_file:
                 dump(data, tmp_file, indent=4)

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -1,4 +1,4 @@
-import os, shutil, copy, time
+import os, shutil, copy, time, tempfile
 from json import load, dump, JSONDecodeError
 from jsonschema import validate, ValidationError
 from dotenv import load_dotenv, find_dotenv
@@ -28,6 +28,26 @@ class ConfigManager:
         # self.update_config_with_top_level_defaults()
         self.schema = self._load_schema()
         self.config = self._load_and_validate_config()
+
+    def _atomic_write(self, data):
+        """Write config atomically to prevent corruption on crash or kill signal.
+
+        Writes to a temp file in the same directory, then calls os.replace()
+        which maps to a single rename(2) syscall that cannot be interrupted.
+        The previous file remains intact until the rename succeeds.
+        """
+        dir_name = os.path.dirname(self.file_path)
+        fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as tmp_file:
+                dump(data, tmp_file, indent=4)
+            os.replace(tmp_path, self.file_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def _load_schema(self):
         with open(self.schema_path, "r") as schema_file:
@@ -93,8 +113,7 @@ class ConfigManager:
                     updated_config[key] = existing_config[key]
 
             if updated:
-                with open(self.file_path, "w") as config_file:
-                    dump(updated_config, config_file, indent=4)
+                self._atomic_write(updated_config)
         except Exception as e:
             raise ValueError(f"Error during update_config_with_top_level_defaults: {e}")
 
@@ -134,8 +153,7 @@ class ConfigManager:
             if pruned_config != existing_config:
                 backup_path = self.file_path + ".bak"
                 shutil.copyfile(self.file_path, backup_path)
-                with open(self.file_path, "w") as config_file:
-                    dump(pruned_config, config_file, indent=4)
+                self._atomic_write(pruned_config)
 
             self.config = pruned_config
         except Exception as e:
@@ -317,12 +335,10 @@ class ConfigManager:
             if not update_nested_config(full_config, process_name, section_config):
                 raise ValueError(f"Failed to locate process {process_name} in file.")
 
-            with open(self.file_path, "w") as config_file:
-                dump(full_config, config_file, indent=4)
+            self._atomic_write(full_config)
         else:
             ConfigManager.fix_null_strings(self.config, self.schema)
-            with open(self.file_path, "w") as config_file:
-                dump(self.config, config_file, indent=4)
+            self._atomic_write(self.config)
 
     def get(self, key, section=None, normalize_case=False):
         value = (

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -35,10 +35,20 @@ class ConfigManager:
         Writes to a temp file in the same directory, then calls os.replace()
         which maps to a single rename(2) syscall that cannot be interrupted.
         The previous file remains intact until the rename succeeds.
+
+        Preserves the original file's mode and ownership (when permitted) so
+        permissions don't silently degrade to mkstemp's default 0o600 over time.
         """
         dir_name = os.path.dirname(self.file_path)
         fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
         try:
+            try:
+                st = os.stat(self.file_path)
+                os.fchmod(fd, st.st_mode & 0o777)
+                if hasattr(os, "fchown"):
+                    os.fchown(fd, st.st_uid, st.st_gid)
+            except (FileNotFoundError, PermissionError):
+                pass
             with os.fdopen(fd, "w") as tmp_file:
                 dump(data, tmp_file, indent=4)
             os.replace(tmp_path, self.file_path)


### PR DESCRIPTION
## Problem

`dumb_config.json` gets corrupted when the container is stopped or crashes while `config_loader.py` is mid-write. The current pattern truncates the file on open, then writes — if interrupted the file contains partial JSON or a mix of old + new content:

```
ValueError: JSON syntax error in dumb_config.json: Extra data at line 1253, column 1
```

This causes a crash loop on next startup (JSON parse fails → exit code 1 → immediate restart → repeat).

Observed three times in one week (Feb 17, Feb 22, Feb 23 2026), consistently triggered by `docker stop` sending SIGTERM while a config save was in progress during graceful shutdown.

Reported in #132.

## Root cause

All four write sites in `config_loader.py` use the same pattern:

```python
with open(self.file_path, "w") as config_file:
    dump(data, config_file, indent=4)
```

`open(path, "w")` truncates the file immediately. If the process is killed before `dump()` finishes flushing, the file is empty or partial. On Linux, kernel buffering can also cause old file content to be interleaved with new content, producing the "Extra data" error.

## Fix

Add a single `_atomic_write()` helper and replace all 4 write sites:

```python
def _atomic_write(self, data):
    dir_name = os.path.dirname(self.file_path)
    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
    try:
        with os.fdopen(fd, "w") as tmp_file:
            dump(data, tmp_file, indent=4)
        os.replace(tmp_path, self.file_path)
    except Exception:
        try:
            os.unlink(tmp_path)
        except OSError:
            pass
        raise
```

`os.replace()` maps to a single `rename(2)` syscall — it cannot be interrupted mid-way. The old file remains intact until the rename succeeds. No partial state is ever visible to a reader.

## Changes

- `utils/config_loader.py`: add `_atomic_write()` helper + `import tempfile`, replace 4 non-atomic write sites
- No new dependencies (stdlib `os` + `tempfile` only)

## Affected methods

| Method | Location |
|--------|----------|
| `update_config_with_top_level_defaults` | line ~96 |
| `update_config_with_defaults` | line ~137 |
| `save_config` (section path) | line ~320 |
| `save_config` (full path) | line ~324 |

Closes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration saving to use atomic file writes, reducing risk of partial or corrupted config files during updates.
  * New write process preserves file permissions and ownership where possible and cleans up temporary files on error, increasing reliability for concurrent or interrupted saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->