### PR TITLE
fix(mediastorm): support amd64 jellyfin-ffmpeg OCI links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -738,6 +738,7 @@ MEDIASTORM_ENV_STRMR_WEB_APP_DIR=/mediastorm/runtime/web
 MEDIASTORM_ENV_MEDIASTORM_IROH_DIRECT_DIR=/mediastorm/runtime/iroh
 MEDIASTORM_ENV_DATABASE_URL=
 MEDIASTORM_ENV_PATH=/mediastorm/runtime/python-venv/bin:/mediastorm/runtime/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+MEDIASTORM_ENV_LD_LIBRARY_PATH=/mediastorm/runtime/lib/jellyfin-ffmpeg/lib
 MEDIASTORM_ENV_LIBGL_ALWAYS_SOFTWARE=1
 MEDIASTORM_ENV_VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lavapipe_icd.json
 

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -1,4 +1,5 @@
 import io
+import os
 import tarfile
 import tempfile
 import unittest
@@ -35,6 +36,32 @@ def _write_symlink_layer(path: Path, name: str, target: str) -> None:
         info.linkname = target
         info.mode = 0o777
         archive.addfile(info)
+
+
+def _write_mixed_layer(
+    path: Path,
+    *,
+    files: dict[str, tuple[bytes, int]] | None = None,
+    symlinks: dict[str, str] | None = None,
+    directories: tuple[str, ...] = (),
+) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for name in directories:
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.DIRTYPE
+            info.mode = 0o755
+            archive.addfile(info)
+        for name, (content, mode) in (files or {}).items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            info.mode = mode
+            archive.addfile(info, io.BytesIO(content))
+        for name, target in (symlinks or {}).items():
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.SYMTYPE
+            info.linkname = target
+            info.mode = 0o777
+            archive.addfile(info)
 
 
 class _FakeOCIClient:
@@ -127,6 +154,119 @@ class MediaStormInstallerTests(unittest.TestCase):
                 MediaStormInstallError, "unsupported link: root/mediastorm"
             ):
                 apply_mediastorm_layer(layer, root / "output")
+
+    def test_extracts_jellyfin_bundle_as_runtime_relative_links(self):
+        # The amd64 images install ffmpeg/ffprobe from the jellyfin-ffmpeg
+        # package and expose them through absolute container links under
+        # /usr/local/bin. The staged runtime must keep those links relative.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            layer = root / "layer.tar.gz"
+            output = root / "output"
+            _write_mixed_layer(
+                layer,
+                directories=(
+                    "usr/lib/jellyfin-ffmpeg/",
+                    "usr/lib/jellyfin-ffmpeg/lib/",
+                ),
+                files={
+                    "usr/lib/jellyfin-ffmpeg/ffmpeg": (b"ffmpeg-binary", 0o755),
+                    "usr/lib/jellyfin-ffmpeg/ffprobe": (b"ffprobe-binary", 0o755),
+                    "usr/lib/jellyfin-ffmpeg/lib/libz.so.1.3.1": (b"libz", 0o644),
+                },
+                symlinks={
+                    "usr/lib/jellyfin-ffmpeg/lib/libz.so": "libz.so.1.3.1",
+                    "usr/local/bin/ffmpeg": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+                    "usr/local/bin/ffprobe": "/usr/lib/jellyfin-ffmpeg/ffprobe",
+                },
+            )
+
+            apply_mediastorm_layer(layer, output)
+
+            self.assertEqual(
+                (output / "lib" / "jellyfin-ffmpeg" / "ffmpeg").read_bytes(),
+                b"ffmpeg-binary",
+            )
+            self.assertTrue((output / "bin" / "ffmpeg").is_symlink())
+            self.assertEqual(
+                os.readlink(output / "bin" / "ffmpeg"),
+                "../lib/jellyfin-ffmpeg/ffmpeg",
+            )
+            self.assertEqual(
+                os.readlink(output / "bin" / "ffprobe"),
+                "../lib/jellyfin-ffmpeg/ffprobe",
+            )
+            self.assertEqual(
+                os.readlink(output / "lib" / "jellyfin-ffmpeg" / "lib" / "libz.so"),
+                "libz.so.1.3.1",
+            )
+            self.assertEqual(
+                (output / "bin" / "ffmpeg").resolve().read_bytes(),
+                b"ffmpeg-binary",
+            )
+
+    def test_installs_amd64_runtime_with_jellyfin_ffmpeg_links(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            layer = root / "layer.tar.gz"
+            files = {
+                "app/mediastorm": (b"server", 0o755),
+                "opt/strmr-web/index.html": (b"web", 0o644),
+                "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
+                "app/version.txt": (b"1.5.0\n20260811\n", 0o644),
+                "parse_title.py": (b"", 0o644),
+                "parse_title_batch.py": (b"", 0o644),
+                "search_subtitles.py": (b"", 0o644),
+                "download_subtitle.py": (b"", 0o644),
+                "detect_credits.py": (b"", 0o644),
+                "usr/lib/jellyfin-ffmpeg/ffmpeg": (b"ffmpeg-binary", 0o755),
+                "usr/lib/jellyfin-ffmpeg/ffprobe": (b"ffprobe-binary", 0o755),
+                "usr/local/bin/yt-dlp": (b"yt-dlp", 0o755),
+                "usr/local/bin/deno": (b"deno", 0o755),
+            }
+            _write_mixed_layer(
+                layer,
+                files=files,
+                symlinks={
+                    "root/mediastorm": "/app/mediastorm",
+                    "usr/local/bin/ffmpeg": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+                    "usr/local/bin/ffprobe": "/usr/lib/jellyfin-ffmpeg/ffprobe",
+                },
+            )
+
+            def fake_python_environment(runtime):
+                python = runtime / "python-venv" / "bin" / "python3"
+                python.parent.mkdir(parents=True)
+                python.write_text("python", encoding="utf-8")
+
+            config = {
+                "config_dir": str(root / "mediastorm"),
+            }
+            with patch(
+                "utils.mediastorm_installer._build_python_environment",
+                side_effect=fake_python_environment,
+            ):
+                result = install_mediastorm_runtime(
+                    config,
+                    "latest",
+                    client=_FakeOCIClient([layer]),
+                )
+
+            runtime = root / "mediastorm" / "runtime"
+            self.assertEqual(result["version"], "v1.5.0-20260811")
+            self.assertTrue(mediastorm_runtime_ready(runtime))
+            self.assertEqual(
+                os.readlink(runtime / "bin" / "ffmpeg"),
+                "../lib/jellyfin-ffmpeg/ffmpeg",
+            )
+            self.assertEqual(
+                (runtime / "bin" / "ffmpeg").resolve().read_bytes(),
+                b"ffmpeg-binary",
+            )
+            self.assertEqual(
+                (runtime / "lib" / "jellyfin-ffmpeg" / "ffprobe").read_bytes(),
+                b"ffprobe-binary",
+            )
 
     def test_installs_verified_runtime_atomically(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/utils/dumb_config.json
+++ b/utils/dumb_config.json
@@ -845,6 +845,7 @@
       "MEDIASTORM_IROH_DIRECT_DIR": "/mediastorm/runtime/iroh",
       "DATABASE_URL": "",
       "PATH": "/mediastorm/runtime/python-venv/bin:/mediastorm/runtime/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "LD_LIBRARY_PATH": "/mediastorm/runtime/lib/jellyfin-ffmpeg/lib",
       "LIBGL_ALWAYS_SOFTWARE": "1",
       "VK_ICD_FILENAMES": "/usr/share/vulkan/icd.d/lavapipe_icd.json"
     }

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -40,10 +41,14 @@ _SOURCE_FILES = {
     "usr/local/bin/yt-dlp": "bin/yt-dlp",
     "usr/local/bin/deno": "bin/deno",
 }
-_MEDIASTORM_COMPATIBILITY_LINK = ("root/mediastorm", "/app/mediastorm")
 _SOURCE_DIRECTORIES = {
     "opt/strmr-web": "web",
     "opt/iroh": "iroh",
+    # The amd64 images install ffmpeg/ffprobe from the jellyfin-ffmpeg package
+    # and expose them through absolute container links under /usr/local/bin.
+    # Extract the whole bundle so the binaries and their bundled libraries
+    # travel with the staged runtime.
+    "usr/lib/jellyfin-ffmpeg": "lib/jellyfin-ffmpeg",
 }
 
 
@@ -71,6 +76,27 @@ def _mapped_path(source_path: str) -> str | None:
         if source_path.startswith(prefix):
             return f"{target_dir}/{source_path[len(prefix):]}"
     return None
+
+
+def _mapped_link_target(source_path: str, linkname: str) -> str | None:
+    """Resolve a container link to its allowlisted runtime path, if any.
+
+    Absolute link targets resolve from the container root; relative targets
+    resolve from the link's own directory. Only targets that stay inside an
+    allowlisted source path are considered supported.
+    """
+    target = str(linkname or "").replace("\\", "/")
+    if not target:
+        return None
+    if target.startswith("/"):
+        resolved = posixpath.normpath(target[1:])
+    else:
+        resolved = posixpath.normpath(
+            posixpath.join(posixpath.dirname(source_path), target)
+        )
+    if not resolved or ".." in PurePosixPath(resolved).parts:
+        return None
+    return _mapped_path(resolved)
 
 
 def _safe_destination(root: Path, relative_path: str) -> Path:
@@ -137,19 +163,37 @@ def apply_mediastorm_layer(
                 continue
             destination = _safe_destination(root, mapped)
             if member.issym() or member.islnk():
-                if (
-                    member.issym()
-                    and (source_path, member.linkname) == _MEDIASTORM_COMPATIBILITY_LINK
-                ):
-                    # Current upstream images keep /root/mediastorm as a
-                    # compatibility alias while installing the real binary at
-                    # /app/mediastorm. Extract the allowlisted regular file
-                    # from its own layer and do not reproduce the absolute
-                    # container symlink inside DUMB's staged runtime.
-                    continue
-                raise MediaStormInstallError(
-                    f"mediastorm OCI runtime contains an unsupported link: {source_path}"
+                mapped_target = (
+                    _mapped_link_target(source_path, member.linkname)
+                    if member.issym()
+                    else None
                 )
+                if mapped_target is None:
+                    raise MediaStormInstallError(
+                        f"mediastorm OCI runtime contains an unsupported link: {source_path}"
+                    )
+                if mapped_target == mapped:
+                    # The link is a container-internal alias for the same
+                    # runtime file (for example /root/mediastorm ->
+                    # /app/mediastorm). The regular file is extracted from its
+                    # own layer entry, so do not reproduce the alias.
+                    continue
+                # Rewrite container links as runtime-relative symlinks so the
+                # staged runtime stays self-contained (for example
+                # /usr/local/bin/ffmpeg -> /usr/lib/jellyfin-ffmpeg/ffmpeg).
+                relative_target = posixpath.relpath(
+                    mapped_target, posixpath.dirname(mapped)
+                )
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if destination.exists() or destination.is_symlink():
+                    _remove_existing(destination)
+                try:
+                    destination.symlink_to(relative_target)
+                except OSError as exc:
+                    raise MediaStormInstallError(
+                        f"Unable to install mediastorm OCI link: {source_path}"
+                    ) from exc
+                continue
             if member.isdir():
                 if destination.exists() and not destination.is_dir():
                     _remove_existing(destination)


### PR DESCRIPTION
### What changed

Upstream amd64 builds of mediastorm now ship `usr/local/bin/ffmpeg`/`ffprobe` as symlinks into the jellyfin-ffmpeg bundle instead of static binaries, which broke OCI installs and updates with `unsupported link: usr/local/bin/ffmpeg`.

- **`utils/mediastorm_installer.py`**: allow symlinks whose targets resolve inside allowlisted paths, rewritten as runtime-relative links (e.g. `bin/ffmpeg -> ../lib/jellyfin-ffmpeg/ffmpeg`); extract the jellyfin-ffmpeg bundle; unmapped/escaping link targets are still rejected.
- **`utils/dumb_config.json` / `.env.example`**: add `LD_LIBRARY_PATH` pointing at the extracted bundle's lib dir so the jellyfin binaries can load their bundled libraries (they have a container-absolute `RUNPATH` baked in). Harmless on layouts without the bundle.
- **`tests/test_mediastorm_installer.py`**: regression tests for the amd64 jellyfin layout (layer extraction + full install).

### Verifications

- Extracted the same artifact that failed (amd64 jellyfin layer from Docker Hub) — relative links are correct, there are no absolute symlinks now.
- Full live-registry install succeeds (v1.5.0-20260811, runtime ready); checked both the old symlinked and current static-binary layouts.
- `make metadata`, env drift, Black, Ruff, compileall, and secret scan pass; all mediastorm-related tests pass. Remaining suite failures are pre-existing environment-specific ones.

### Docs follow-up

Note the new `MEDIASTORM_ENV_LD_LIBRARY_PATH` default in DUMB_docs if process env is documented there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bundled Jellyfin FFmpeg libraries to the MediaStorm runtime environment.
  * Configured library discovery automatically through the runtime library path.
* **Bug Fixes**
  * Improved installation of FFmpeg files, directories, and symbolic links.
  * Ensured supported links resolve correctly after installation and rejected unsupported links safely.
* **Tests**
  * Added coverage for extracting and installing mixed file layers, including symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->