### PR TITLE
fix(mediastorm): ffmpeg/probe linking issue

### DIFF
--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from utils.mediastorm_installer import (
     MediaStormInstallError,
+    _elf_header_layout,
     _mediastorm_install_request,
     apply_mediastorm_layer,
     install_mediastorm_runtime,
@@ -147,6 +148,44 @@ def _minimal_elf_bytes(needed: list[str]) -> bytes:
         ]
     )
     return ehdr + phdr + dynstr + dynamic + sections
+
+
+def _sectionless_elf_bytes() -> bytes:
+    """Build a minimal ELF64 executable without a section header table.
+
+    e_shoff == 0 with e_shnum == 0 marks an absent section table, which is
+    valid for static binaries. Identification fields stay standard.
+    """
+    e_ident = b"\x7fELF" + bytes([2, 1, 1]) + bytes(9)
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        e_ident,
+        2,  # ET_EXEC
+        62,  # EM_X86_64
+        1,
+        0x400000,
+        64,
+        0,  # e_shoff: no section header table
+        0,
+        0,  # e_shentsize
+        0,  # e_shnum
+        0,
+        0,
+        0,
+        0,
+    )
+    phdr = struct.pack(
+        "<IIQQQQQQ",
+        1,  # PT_LOAD
+        5,  # PF_R | PF_X
+        0,
+        0x400000,
+        0x400000,
+        len(ehdr) + 56,
+        len(ehdr) + 56,
+        0x1000,
+    )
+    return ehdr + phdr
 
 
 class _FakeOCIClient:
@@ -338,6 +377,27 @@ class MediaStormInstallerTests(unittest.TestCase):
             )
             self.assertEqual((staging / "libc.so.6").read_bytes(), b"libc")
             self.assertFalse((staging / "libunrelated.so.1").exists())
+
+    def test_rejects_unknown_elf_identification_fields(self):
+        # EI_CLASS/EI_DATA outside their known values must be rejected even
+        # on sectionless files, while valid sectionless ELFs keep their
+        # layout and remain usable as static binaries.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for klass, data in ((0, 1), (3, 1), (1, 0), (2, 3)):
+                with self.subTest(klass=klass, data=data):
+                    content = bytearray(_sectionless_elf_bytes())
+                    content[4] = klass
+                    content[5] = data
+                    path = root / f"bad-{klass}-{data}.bin"
+                    path.write_bytes(bytes(content))
+                    self.assertIsNone(_elf_header_layout(path))
+            valid = root / "sectionless.bin"
+            valid.write_bytes(_sectionless_elf_bytes())
+            is64, endian, shoff, shentsize, shnum = _elf_header_layout(valid)
+            self.assertTrue(is64)
+            self.assertEqual(endian, "<")
+            self.assertEqual((shoff, shentsize, shnum), (0, 0, 0))
 
     def test_runtime_ready_requires_resolvable_library_closure(self):
         def write_runtime(root, with_codec_lib=False, malformed_ffmpeg=False):

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -68,7 +68,7 @@ def _write_mixed_layer(
             archive.addfile(info)
 
 
-def _minimal_elf_bytes(needed: list[str]) -> bytes:
+def _minimal_elf_bytes(needed: list[str], bad_strtab: bool = False) -> bytes:
     """Build a minimal ELF64 dynamic executable with the given DT_NEEDED
     entries, so the installer's runtime library closure sees real deps.
 
@@ -77,6 +77,9 @@ def _minimal_elf_bytes(needed: list[str]) -> bytes:
     parser resolves the dynamic string table through SHT_DYNAMIC.sh_link
     (which points at the same .dynstr section).
     Do not rely on changing e_shstrndx alone; the parser never reads it.
+    With bad_strtab=True the .dynstr section header claims offsets past the
+    end of the file while the ELF header stays valid, for rejection-path
+    tests.
     """
     dynstr = b"\x00" + b"\x00".join(name.encode() for name in needed) + b"\x00"
     str_offsets = {}
@@ -140,10 +143,16 @@ def _minimal_elf_bytes(needed: list[str]) -> bytes:
         )
 
     shstr_off = total - 64
+    if bad_strtab:
+        dynstr_shoff = total + 0x1000
+        dynstr_shsize = 0x1000
+    else:
+        dynstr_shoff = dynstr_off
+        dynstr_shsize = len(dynstr)
     sections = b"".join(
         [
             bytes(64),  # null section
-            shdr(0, 3, dynstr_off, len(dynstr), addralign=1),  # .dynstr
+            shdr(0, 3, dynstr_shoff, dynstr_shsize, addralign=1),  # .dynstr
             shdr(0, 6, dynamic_off, len(dynamic), link=1, addralign=8),  # .dynamic
             shdr(0, 11, shstr_off, 0, link=1, addralign=8),  # .dynsym
             shdr(0, 3, shstr_off, 1, addralign=1),  # shstrtab placeholder
@@ -428,9 +437,7 @@ class MediaStormInstallerTests(unittest.TestCase):
             outside = root / "outside.so"
             outside.write_bytes(_minimal_elf_bytes([]))
             (staging / "libescape-absolute.so.1").symlink_to(outside)
-            (staging / "libescape-traversal.so.1").symlink_to(
-                "../../../outside.so"
-            )
+            (staging / "libescape-traversal.so.1").symlink_to("../../../outside.so")
             (staging / "libloop.so.1").symlink_to("libloop.so.1")
 
             missing = _runtime_missing_libraries(runtime)
@@ -459,6 +466,85 @@ class MediaStormInstallerTests(unittest.TestCase):
             self.assertFalse((bundle / "libescape-traversal.so.1").exists())
             self.assertTrue(outside.exists())
             self.assertFalse(staging.exists())
+
+    def test_runtime_closure_rejects_invalid_dynamic_metadata(self):
+        # Files with malformed or out-of-bounds dynamic metadata must be
+        # rejected rather than trusted as dependency-free: a corrupt staged
+        # library is not copied and a corrupt bundled library is not
+        # indexed, so both stay unresolved.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime = root / "runtime"
+            (runtime / "bin").mkdir(parents=True)
+            staging = runtime / "lib" / ".system-libs"
+            staging.mkdir(parents=True)
+            bundle = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+            bundle.mkdir(parents=True)
+            (runtime / "bin" / "ffmpeg").write_bytes(
+                _minimal_elf_bytes(["libbroken-staged.so.1", "libbroken-bundled.so.1"])
+            )
+            (runtime / "bin" / "ffprobe").write_bytes(_minimal_elf_bytes([]))
+            (staging / "libbroken-staged.so.1").write_bytes(
+                _minimal_elf_bytes([], bad_strtab=True)
+            )
+            (bundle / "libbroken-bundled.so.1").write_bytes(
+                _minimal_elf_bytes([], bad_strtab=True)
+            )
+
+            expected = ["libbroken-bundled.so.1", "libbroken-staged.so.1"]
+            self.assertEqual(sorted(_runtime_missing_libraries(runtime)), expected)
+            self.assertEqual(sorted(_resolve_runtime_libraries(runtime)), expected)
+            self.assertFalse((bundle / "libbroken-staged.so.1").exists())
+
+    def test_runtime_ready_rejects_out_of_bounds_dynamic_strtab(self):
+        # A valid ELF header with an out-of-bounds dynamic string table
+        # makes the binary unverifiable, so ready() must reject it; a truly
+        # sectionless static binary keeps passing.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime = root / "runtime"
+            for relative in (
+                "mediastorm",
+                "web/index.html",
+                "iroh/iroh-direct-spike",
+                "python-venv/bin/python3",
+                "bin/ffmpeg",
+                "bin/ffprobe",
+                "bin/yt-dlp",
+                "bin/deno",
+            ):
+                path = runtime / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                if relative == "bin/ffmpeg":
+                    path.write_bytes(
+                        _minimal_elf_bytes(["libavcodec.so.61"], bad_strtab=True)
+                    )
+                elif relative == "bin/ffprobe":
+                    path.write_bytes(_minimal_elf_bytes([]))
+                else:
+                    path.write_text(relative, encoding="utf-8")
+            self.assertFalse(mediastorm_runtime_ready(runtime))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime = root / "runtime"
+            for relative in (
+                "mediastorm",
+                "web/index.html",
+                "iroh/iroh-direct-spike",
+                "python-venv/bin/python3",
+                "bin/ffmpeg",
+                "bin/ffprobe",
+                "bin/yt-dlp",
+                "bin/deno",
+            ):
+                path = runtime / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                if relative in ("bin/ffmpeg", "bin/ffprobe"):
+                    path.write_bytes(_sectionless_elf_bytes())
+                else:
+                    path.write_text(relative, encoding="utf-8")
+            self.assertTrue(mediastorm_runtime_ready(runtime))
 
     def test_runtime_ready_requires_resolvable_library_closure(self):
         def write_runtime(root, with_codec_lib=False, malformed_ffmpeg=False):
@@ -611,7 +697,10 @@ class MediaStormInstallerTests(unittest.TestCase):
                     _minimal_elf_bytes(["libvorbis.so.0"]),
                     0o644,
                 ),
-                "usr/lib/x86_64-linux-gnu/libx264.so.164": (b"x264", 0o644),
+                "usr/lib/x86_64-linux-gnu/libx264.so.164": (
+                    _minimal_elf_bytes([]),
+                    0o644,
+                ),
                 "usr/lib/x86_64-linux-gnu/libvorbis.so.0.4.9": (
                     _minimal_elf_bytes([]),
                     0o644,
@@ -673,7 +762,10 @@ class MediaStormInstallerTests(unittest.TestCase):
                 (bundle_lib / "libvorbis.so.0").read_bytes(),
                 _minimal_elf_bytes([]),
             )
-            self.assertEqual((bundle_lib / "libx264.so.164").read_bytes(), b"x264")
+            self.assertEqual(
+                (bundle_lib / "libx264.so.164").read_bytes(),
+                _minimal_elf_bytes([]),
+            )
             self.assertFalse((runtime / "lib" / ".system-libs").exists())
 
     def test_installs_verified_runtime_atomically(self):

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -1,5 +1,6 @@
 import io
 import os
+import struct
 import tarfile
 import tempfile
 import unittest
@@ -66,9 +67,13 @@ def _write_mixed_layer(
 
 def _minimal_elf_bytes(needed: list[str]) -> bytes:
     """Build a minimal ELF64 dynamic executable with the given DT_NEEDED
-    entries, so the installer's runtime library closure sees real deps."""
-    import struct
+    entries, so the installer's runtime library closure sees real deps.
 
+    The fixture is shaped for _elf_dynamic_info(): the zero-sized SHT_DYNSYM
+    and the placeholder linked string table are intentional, because the
+    parser resolves the dynamic string table through SHT_DYNSYM.sh_link.
+    Do not rely on changing e_shstrndx alone; the parser never reads it.
+    """
     dynstr = b"\x00" + b"\x00".join(name.encode() for name in needed) + b"\x00"
     str_offsets = {}
     cursor = 1
@@ -141,10 +146,6 @@ def _minimal_elf_bytes(needed: list[str]) -> bytes:
         ]
     )
     return ehdr + phdr + dynstr + dynamic + sections
-
-
-def _write_minimal_elf(path: Path, needed: list[str]) -> None:
-    path.write_bytes(_minimal_elf_bytes(needed))
 
 
 class _FakeOCIClient:
@@ -338,38 +339,64 @@ class MediaStormInstallerTests(unittest.TestCase):
             self.assertFalse((staging / "libunrelated.so.1").exists())
 
     def test_runtime_ready_requires_resolvable_library_closure(self):
-        def write_runtime(root, with_codec_lib):
+        def write_runtime(root, with_codec_lib=False, malformed_ffmpeg=False):
             runtime = root / "runtime"
             for relative in (
                 "mediastorm",
                 "web/index.html",
                 "iroh/iroh-direct-spike",
                 "python-venv/bin/python3",
-                "bin/ffprobe",
                 "bin/yt-dlp",
                 "bin/deno",
             ):
                 path = runtime / relative
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_text(relative, encoding="utf-8")
+            (runtime / "bin" / "ffprobe").write_bytes(_minimal_elf_bytes([]))
             bundle = runtime / "lib" / "jellyfin-ffmpeg"
             bundle.mkdir(parents=True, exist_ok=True)
-            (bundle / "ffmpeg").write_bytes(
-                _minimal_elf_bytes(["libavcodec.so.61", "libmp3lame.so.0"])
-            )
+            if malformed_ffmpeg:
+                # Truncated ELF: the header claims a section table the file
+                # does not contain. ready() must reject it without raising.
+                elf = _minimal_elf_bytes(["libmediastorm-test-codec.so.0"])
+                (bundle / "ffmpeg").write_bytes(elf[: len(elf) // 2])
+            else:
+                (bundle / "ffmpeg").write_bytes(
+                    _minimal_elf_bytes(
+                        ["libavcodec.so.61", "libmediastorm-test-codec.so.0"]
+                    )
+                )
             (runtime / "bin" / "ffmpeg").unlink(missing_ok=True)
             (runtime / "bin" / "ffmpeg").symlink_to("../lib/jellyfin-ffmpeg/ffmpeg")
             (bundle / "lib").mkdir(exist_ok=True)
             (bundle / "lib" / "libavcodec.so.61").write_bytes(_minimal_elf_bytes([]))
             if with_codec_lib:
-                (bundle / "lib" / "libmp3lame.so.0").write_bytes(_minimal_elf_bytes([]))
+                (bundle / "lib" / "libmediastorm-test-codec.so.0").write_bytes(
+                    _minimal_elf_bytes([])
+                )
             return runtime
 
+        # Jellyfin layout without the codec libraries cannot run ffmpeg.
+        # Each case gets its own root so the write_runtime invocations are
+        # isolated from each other.
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
-            # Jellyfin layout without the codec libraries cannot run ffmpeg.
-            self.assertFalse(mediastorm_runtime_ready(write_runtime(root, False)))
-            self.assertTrue(mediastorm_runtime_ready(write_runtime(root, True)))
+            self.assertFalse(
+                mediastorm_runtime_ready(write_runtime(root, with_codec_lib=False))
+            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.assertTrue(
+                mediastorm_runtime_ready(write_runtime(root, with_codec_lib=True))
+            )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            # A truncated ffmpeg ELF must not raise and is not ready.
+            self.assertFalse(
+                mediastorm_runtime_ready(
+                    write_runtime(root, with_codec_lib=True, malformed_ffmpeg=True)
+                )
+            )
 
         # Static-binary layouts (arm64 images) never need the bundle libs.
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -387,7 +414,10 @@ class MediaStormInstallerTests(unittest.TestCase):
             ):
                 path = runtime / relative
                 path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(relative, encoding="utf-8")
+                if relative in ("bin/ffmpeg", "bin/ffprobe"):
+                    path.write_bytes(_minimal_elf_bytes([]))
+                else:
+                    path.write_text(relative, encoding="utf-8")
             self.assertTrue(mediastorm_runtime_ready(runtime))
 
     def test_install_fails_when_runtime_needs_unknown_system_library(self):
@@ -456,10 +486,14 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "usr/local/bin/yt-dlp": (b"yt-dlp", 0o755),
                 "usr/local/bin/deno": (b"deno", 0o755),
                 "usr/lib/x86_64-linux-gnu/libmp3lame.so.0.0.0": (
-                    b"lame",
+                    _minimal_elf_bytes(["libvorbis.so.0"]),
                     0o644,
                 ),
                 "usr/lib/x86_64-linux-gnu/libx264.so.164": (b"x264", 0o644),
+                "usr/lib/x86_64-linux-gnu/libvorbis.so.0.4.9": (
+                    _minimal_elf_bytes([]),
+                    0o644,
+                ),
             }
             _write_mixed_layer(
                 layer,
@@ -469,6 +503,7 @@ class MediaStormInstallerTests(unittest.TestCase):
                     "usr/local/bin/ffmpeg": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
                     "usr/local/bin/ffprobe": "/usr/lib/jellyfin-ffmpeg/ffprobe",
                     "usr/lib/x86_64-linux-gnu/libmp3lame.so.0": ("libmp3lame.so.0.0.0"),
+                    "usr/lib/x86_64-linux-gnu/libvorbis.so.0": ("libvorbis.so.0.4.9"),
                 },
             )
 
@@ -508,7 +543,14 @@ class MediaStormInstallerTests(unittest.TestCase):
             # The codec libraries ffmpeg links against were carried into the
             # bundle directory and the staging area was pruned.
             bundle_lib = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
-            self.assertEqual((bundle_lib / "libmp3lame.so.0").read_bytes(), b"lame")
+            self.assertEqual(
+                (bundle_lib / "libmp3lame.so.0").read_bytes(),
+                _minimal_elf_bytes(["libvorbis.so.0"]),
+            )
+            self.assertEqual(
+                (bundle_lib / "libvorbis.so.0").read_bytes(),
+                _minimal_elf_bytes([]),
+            )
             self.assertEqual((bundle_lib / "libx264.so.164").read_bytes(), b"x264")
             self.assertFalse((runtime / "lib" / ".system-libs").exists())
 
@@ -527,7 +569,9 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "download_subtitle.py": (b"", 0o644),
                 "detect_credits.py": (b"", 0o644),
             }
-            for binary in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+            for binary in ("ffmpeg", "ffprobe"):
+                entries[f"usr/local/bin/{binary}"] = (_minimal_elf_bytes([]), 0o755)
+            for binary in ("yt-dlp", "deno"):
                 entries[f"usr/local/bin/{binary}"] = (b"binary", 0o755)
             _write_layer(layer, entries)
 
@@ -582,7 +626,9 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
                 "app/version.txt": (b"1.5.0\n20260807\n", 0o644),
             }
-            for binary in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+            for binary in ("ffmpeg", "ffprobe"):
+                entries[f"usr/local/bin/{binary}"] = (_minimal_elf_bytes([]), 0o755)
+            for binary in ("yt-dlp", "deno"):
                 entries[f"usr/local/bin/{binary}"] = (b"binary", 0o755)
             _write_layer(layer, entries)
 
@@ -620,7 +666,10 @@ class MediaStormInstallerTests(unittest.TestCase):
             ):
                 target = runtime / relative
                 target.parent.mkdir(parents=True, exist_ok=True)
-                target.write_text("runtime", encoding="utf-8")
+                if relative in ("bin/ffmpeg", "bin/ffprobe"):
+                    target.write_bytes(_minimal_elf_bytes([]))
+                else:
+                    target.write_text("runtime", encoding="utf-8")
             (runtime / "version.txt").write_text("v1.5.0-20260806\n", encoding="utf-8")
             (runtime / "install-selector.txt").write_text("latest\n", encoding="utf-8")
             old_digest = "sha256:" + "c" * 64
@@ -652,7 +701,9 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
                 "app/version.txt": (b"1.5.0\n20260711\n", 0o644),
             }
-            for binary in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+            for binary in ("ffmpeg", "ffprobe"):
+                entries[f"usr/local/bin/{binary}"] = (_minimal_elf_bytes([]), 0o755)
+            for binary in ("yt-dlp", "deno"):
                 entries[f"usr/local/bin/{binary}"] = (b"binary", 0o755)
             _write_layer(layer, entries)
 
@@ -699,7 +750,9 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
                 "app/version.txt": (b"1.5.0\n20260711\n", 0o644),
             }
-            for binary in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+            for binary in ("ffmpeg", "ffprobe"):
+                entries[f"usr/local/bin/{binary}"] = (_minimal_elf_bytes([]), 0o755)
+            for binary in ("yt-dlp", "deno"):
                 entries[f"usr/local/bin/{binary}"] = (b"binary", 0o755)
             _write_layer(layer, entries)
 
@@ -741,7 +794,9 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
                 "app/version.txt": (b"1.5.0\n20260806\n", 0o644),
             }
-            for binary in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+            for binary in ("ffmpeg", "ffprobe"):
+                entries[f"usr/local/bin/{binary}"] = (_minimal_elf_bytes([]), 0o755)
+            for binary in ("yt-dlp", "deno"):
                 entries[f"usr/local/bin/{binary}"] = (b"binary", 0o755)
             _write_layer(layer, entries)
 

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -170,20 +170,20 @@ def _sectionless_elf_bytes() -> bytes:
     e_ident = b"\x7fELF" + bytes([2, 1, 1]) + bytes(9)
     ehdr = struct.pack(
         "<16sHHIQQQIHHHHHH",
-        e_ident,
-        2,  # ET_EXEC
-        62,  # EM_X86_64
-        1,
-        0x400000,
-        64,
+        e_ident,  # e_ident
+        2,  # e_type: ET_EXEC
+        62,  # e_machine: EM_X86_64
+        1,  # e_version
+        0x400000,  # e_entry
+        64,  # e_phoff: program headers immediately after the header
         0,  # e_shoff: no section header table
-        0,
-        0,  # e_shentsize
-        0,  # e_shnum
-        0,
-        0,
-        0,
-        0,
+        0,  # e_flags
+        64,  # e_ehsize: ELF header size
+        56,  # e_phentsize: program header entry size
+        1,  # e_phnum: one program header
+        0,  # e_shentsize: no sections
+        0,  # e_shnum: no sections
+        0,  # e_shstrndx: no section name string table
     )
     phdr = struct.pack(
         "<IIQQQQQQ",

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -11,6 +11,8 @@ from utils.mediastorm_installer import (
     MediaStormInstallError,
     _elf_header_layout,
     _mediastorm_install_request,
+    _resolve_runtime_libraries,
+    _runtime_missing_libraries,
     apply_mediastorm_layer,
     install_mediastorm_runtime,
     mediastorm_app_version_text,
@@ -398,6 +400,65 @@ class MediaStormInstallerTests(unittest.TestCase):
             self.assertTrue(is64)
             self.assertEqual(endian, "<")
             self.assertEqual((shoff, shentsize, shnum), (0, 0, 0))
+
+    def test_staged_library_symlinks_must_resolve_inside_staging(self):
+        # Staged links may only target files inside lib/.system-libs.
+        # Absolute and traversal targets are rejected as unresolved and are
+        # never copied, while in-staging targets keep resolving.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime = root / "runtime"
+            (runtime / "bin").mkdir(parents=True)
+            staging = runtime / "lib" / ".system-libs"
+            staging.mkdir(parents=True)
+            bundle = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+            bundle.mkdir(parents=True)
+            (runtime / "bin" / "ffmpeg").write_bytes(
+                _minimal_elf_bytes(
+                    [
+                        "libgood.so.1",
+                        "libescape-absolute.so.1",
+                        "libescape-traversal.so.1",
+                        "libloop.so.1",
+                    ]
+                )
+            )
+            (runtime / "bin" / "ffprobe").write_bytes(_minimal_elf_bytes([]))
+            (staging / "libgood.so.1").write_bytes(_minimal_elf_bytes([]))
+            outside = root / "outside.so"
+            outside.write_bytes(_minimal_elf_bytes([]))
+            (staging / "libescape-absolute.so.1").symlink_to(outside)
+            (staging / "libescape-traversal.so.1").symlink_to(
+                "../../../outside.so"
+            )
+            (staging / "libloop.so.1").symlink_to("libloop.so.1")
+
+            missing = _runtime_missing_libraries(runtime)
+            self.assertEqual(
+                sorted(missing),
+                [
+                    "libescape-absolute.so.1",
+                    "libescape-traversal.so.1",
+                    "libloop.so.1",
+                ],
+            )
+
+            missing = _resolve_runtime_libraries(runtime)
+            self.assertEqual(
+                sorted(missing),
+                [
+                    "libescape-absolute.so.1",
+                    "libescape-traversal.so.1",
+                    "libloop.so.1",
+                ],
+            )
+            self.assertEqual(
+                (bundle / "libgood.so.1").read_bytes(), _minimal_elf_bytes([])
+            )
+            self.assertFalse((bundle / "libescape-absolute.so.1").exists())
+            self.assertFalse((bundle / "libescape-traversal.so.1").exists())
+            self.assertTrue(outside.exists())
+            self.assertFalse(staging.exists())
 
     def test_runtime_ready_requires_resolvable_library_closure(self):
         def write_runtime(root, with_codec_lib=False, malformed_ffmpeg=False):

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -71,7 +71,8 @@ def _minimal_elf_bytes(needed: list[str]) -> bytes:
 
     The fixture is shaped for _elf_dynamic_info(): the zero-sized SHT_DYNSYM
     and the placeholder linked string table are intentional, because the
-    parser resolves the dynamic string table through SHT_DYNSYM.sh_link.
+    parser resolves the dynamic string table through SHT_DYNAMIC.sh_link
+    (which points at the same .dynstr section).
     Do not rely on changing e_shstrndx alone; the parser never reads it.
     """
     dynstr = b"\x00" + b"\x00".join(name.encode() for name in needed) + b"\x00"

--- a/tests/test_mediastorm_installer.py
+++ b/tests/test_mediastorm_installer.py
@@ -64,6 +64,89 @@ def _write_mixed_layer(
             archive.addfile(info)
 
 
+def _minimal_elf_bytes(needed: list[str]) -> bytes:
+    """Build a minimal ELF64 dynamic executable with the given DT_NEEDED
+    entries, so the installer's runtime library closure sees real deps."""
+    import struct
+
+    dynstr = b"\x00" + b"\x00".join(name.encode() for name in needed) + b"\x00"
+    str_offsets = {}
+    cursor = 1
+    for name in needed:
+        str_offsets[name] = cursor
+        cursor += len(name) + 1
+    dynstr_off = 64 + 56
+    dyn_entries = [(1, str_offsets[name]) for name in needed]
+    dyn_entries.append((5, 0x400000 + dynstr_off))  # DT_STRTAB
+    dyn_entries.append((10, len(dynstr)))  # DT_STRSZ
+    dyn_entries.append((0, 0))  # DT_NULL
+    dynamic_off = dynstr_off + len(dynstr)
+    dynamic = b"".join(struct.pack("<qQ", tag, value) for tag, value in dyn_entries)
+    shoff = dynamic_off + len(dynamic)
+    total = shoff + 5 * 64
+
+    e_ident = b"\x7fELF" + bytes([2, 1, 1]) + bytes(9)
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        e_ident,
+        2,  # ET_EXEC
+        62,  # EM_X86_64
+        1,
+        0x400000,
+        64,
+        shoff,
+        0,
+        64,
+        56,
+        1,
+        64,
+        5,
+        0,
+    )
+    phdr = struct.pack(
+        "<IIQQQQQQ",
+        1,  # PT_LOAD
+        5,  # PF_R | PF_X
+        0,
+        0x400000,
+        0x400000,
+        total,
+        total,
+        0x1000,
+    )
+
+    def shdr(name, sh_type, offset, size, link=0, addralign=1):
+        return struct.pack(
+            "<IIQQQQIIQQ",
+            name,
+            sh_type,
+            0,
+            0,
+            offset,
+            size,
+            link,
+            0,
+            addralign,
+            0,
+        )
+
+    shstr_off = total - 64
+    sections = b"".join(
+        [
+            bytes(64),  # null section
+            shdr(0, 3, dynstr_off, len(dynstr), addralign=1),  # .dynstr
+            shdr(0, 6, dynamic_off, len(dynamic), link=1, addralign=8),  # .dynamic
+            shdr(0, 11, shstr_off, 0, link=1, addralign=8),  # .dynsym
+            shdr(0, 3, shstr_off, 1, addralign=1),  # shstrtab placeholder
+        ]
+    )
+    return ehdr + phdr + dynstr + dynamic + sections
+
+
+def _write_minimal_elf(path: Path, needed: list[str]) -> None:
+    path.write_bytes(_minimal_elf_bytes(needed))
+
+
 class _FakeOCIClient:
     def __init__(self, layers, missing_references=None, index_digest=None):
         self.layers = layers
@@ -205,6 +288,152 @@ class MediaStormInstallerTests(unittest.TestCase):
                 b"ffmpeg-binary",
             )
 
+    def test_stages_system_libraries_for_runtime_resolution(self):
+        # The jellyfin-ffmpeg layout links ffmpeg/ffprobe against codec and
+        # support libraries the image installs as system libraries under
+        # /usr/lib/<multiarch>. Every entry there is staged separately so the
+        # runtime library closure can carry exactly what is needed; entries
+        # outside the multiarch tree stay unmapped.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            layer = root / "layer.tar.gz"
+            output = root / "output"
+            _write_mixed_layer(
+                layer,
+                directories=("usr/lib/x86_64-linux-gnu/",),
+                files={
+                    "usr/lib/x86_64-linux-gnu/libmp3lame.so.0.0.0": (
+                        b"lame",
+                        0o644,
+                    ),
+                    "usr/lib/x86_64-linux-gnu/libx264.so.164": (b"x264", 0o644),
+                    "usr/lib/x86_64-linux-gnu/libvorbis.so.0.4.9": (
+                        b"vorbis",
+                        0o644,
+                    ),
+                    "usr/lib/x86_64-linux-gnu/libc.so.6": (b"libc", 0o644),
+                    "usr/lib/something-else/libunrelated.so.1": (b"nope", 0o644),
+                },
+                symlinks={
+                    "usr/lib/x86_64-linux-gnu/libmp3lame.so.0": ("libmp3lame.so.0.0.0"),
+                    "usr/lib/x86_64-linux-gnu/libvorbis.so.0": ("libvorbis.so.0.4.9"),
+                },
+            )
+
+            apply_mediastorm_layer(layer, output)
+
+            staging = output / "lib" / ".system-libs"
+            self.assertEqual((staging / "libmp3lame.so.0.0.0").read_bytes(), b"lame")
+            self.assertTrue((staging / "libmp3lame.so.0").is_symlink())
+            self.assertEqual(
+                os.readlink(staging / "libmp3lame.so.0"),
+                "libmp3lame.so.0.0.0",
+            )
+            self.assertEqual((staging / "libx264.so.164").read_bytes(), b"x264")
+            self.assertEqual(
+                os.readlink(staging / "libvorbis.so.0"),
+                "libvorbis.so.0.4.9",
+            )
+            self.assertEqual((staging / "libc.so.6").read_bytes(), b"libc")
+            self.assertFalse((staging / "libunrelated.so.1").exists())
+
+    def test_runtime_ready_requires_resolvable_library_closure(self):
+        def write_runtime(root, with_codec_lib):
+            runtime = root / "runtime"
+            for relative in (
+                "mediastorm",
+                "web/index.html",
+                "iroh/iroh-direct-spike",
+                "python-venv/bin/python3",
+                "bin/ffprobe",
+                "bin/yt-dlp",
+                "bin/deno",
+            ):
+                path = runtime / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(relative, encoding="utf-8")
+            bundle = runtime / "lib" / "jellyfin-ffmpeg"
+            bundle.mkdir(parents=True, exist_ok=True)
+            (bundle / "ffmpeg").write_bytes(
+                _minimal_elf_bytes(["libavcodec.so.61", "libmp3lame.so.0"])
+            )
+            (runtime / "bin" / "ffmpeg").unlink(missing_ok=True)
+            (runtime / "bin" / "ffmpeg").symlink_to("../lib/jellyfin-ffmpeg/ffmpeg")
+            (bundle / "lib").mkdir(exist_ok=True)
+            (bundle / "lib" / "libavcodec.so.61").write_bytes(_minimal_elf_bytes([]))
+            if with_codec_lib:
+                (bundle / "lib" / "libmp3lame.so.0").write_bytes(_minimal_elf_bytes([]))
+            return runtime
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            # Jellyfin layout without the codec libraries cannot run ffmpeg.
+            self.assertFalse(mediastorm_runtime_ready(write_runtime(root, False)))
+            self.assertTrue(mediastorm_runtime_ready(write_runtime(root, True)))
+
+        # Static-binary layouts (arm64 images) never need the bundle libs.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            runtime = root / "runtime"
+            for relative in (
+                "mediastorm",
+                "web/index.html",
+                "iroh/iroh-direct-spike",
+                "python-venv/bin/python3",
+                "bin/ffmpeg",
+                "bin/ffprobe",
+                "bin/yt-dlp",
+                "bin/deno",
+            ):
+                path = runtime / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(relative, encoding="utf-8")
+            self.assertTrue(mediastorm_runtime_ready(runtime))
+
+    def test_install_fails_when_runtime_needs_unknown_system_library(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            layer = root / "layer.tar.gz"
+            files = {
+                "app/mediastorm": (b"server", 0o755),
+                "opt/strmr-web/index.html": (b"web", 0o644),
+                "opt/iroh/iroh-direct-spike": (b"iroh", 0o755),
+                "app/version.txt": (b"1.5.0\n20260811\n", 0o644),
+                "parse_title.py": (b"", 0o644),
+                "parse_title_batch.py": (b"", 0o644),
+                "search_subtitles.py": (b"", 0o644),
+                "download_subtitle.py": (b"", 0o644),
+                "detect_credits.py": (b"", 0o644),
+                "usr/local/bin/ffmpeg": (
+                    _minimal_elf_bytes(["libmystery.so.1"]),
+                    0o755,
+                ),
+                "usr/local/bin/ffprobe": (_minimal_elf_bytes([]), 0o755),
+                "usr/local/bin/yt-dlp": (b"yt-dlp", 0o755),
+                "usr/local/bin/deno": (b"deno", 0o755),
+            }
+            _write_mixed_layer(layer, files=files)
+
+            def fake_python_environment(runtime):
+                python = runtime / "python-venv" / "bin" / "python3"
+                python.parent.mkdir(parents=True)
+                python.write_text("python", encoding="utf-8")
+
+            config = {
+                "config_dir": str(root / "mediastorm"),
+            }
+            with patch(
+                "utils.mediastorm_installer._build_python_environment",
+                side_effect=fake_python_environment,
+            ):
+                with self.assertRaises(MediaStormInstallError) as raised:
+                    install_mediastorm_runtime(
+                        config,
+                        "latest",
+                        client=_FakeOCIClient([layer]),
+                    )
+            self.assertIn("libmystery.so.1", str(raised.exception))
+
     def test_installs_amd64_runtime_with_jellyfin_ffmpeg_links(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -219,10 +448,18 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "search_subtitles.py": (b"", 0o644),
                 "download_subtitle.py": (b"", 0o644),
                 "detect_credits.py": (b"", 0o644),
-                "usr/lib/jellyfin-ffmpeg/ffmpeg": (b"ffmpeg-binary", 0o755),
-                "usr/lib/jellyfin-ffmpeg/ffprobe": (b"ffprobe-binary", 0o755),
+                "usr/lib/jellyfin-ffmpeg/ffmpeg": (
+                    _minimal_elf_bytes(["libmp3lame.so.0", "libx264.so.164"]),
+                    0o755,
+                ),
+                "usr/lib/jellyfin-ffmpeg/ffprobe": (_minimal_elf_bytes([]), 0o755),
                 "usr/local/bin/yt-dlp": (b"yt-dlp", 0o755),
                 "usr/local/bin/deno": (b"deno", 0o755),
+                "usr/lib/x86_64-linux-gnu/libmp3lame.so.0.0.0": (
+                    b"lame",
+                    0o644,
+                ),
+                "usr/lib/x86_64-linux-gnu/libx264.so.164": (b"x264", 0o644),
             }
             _write_mixed_layer(
                 layer,
@@ -231,6 +468,7 @@ class MediaStormInstallerTests(unittest.TestCase):
                     "root/mediastorm": "/app/mediastorm",
                     "usr/local/bin/ffmpeg": "/usr/lib/jellyfin-ffmpeg/ffmpeg",
                     "usr/local/bin/ffprobe": "/usr/lib/jellyfin-ffmpeg/ffprobe",
+                    "usr/lib/x86_64-linux-gnu/libmp3lame.so.0": ("libmp3lame.so.0.0.0"),
                 },
             )
 
@@ -260,13 +498,19 @@ class MediaStormInstallerTests(unittest.TestCase):
                 "../lib/jellyfin-ffmpeg/ffmpeg",
             )
             self.assertEqual(
-                (runtime / "bin" / "ffmpeg").resolve().read_bytes(),
-                b"ffmpeg-binary",
+                (runtime / "bin" / "ffmpeg").resolve().read_bytes()[:4],
+                b"\x7fELF",
             )
             self.assertEqual(
-                (runtime / "lib" / "jellyfin-ffmpeg" / "ffprobe").read_bytes(),
-                b"ffprobe-binary",
+                (runtime / "lib" / "jellyfin-ffmpeg" / "ffprobe").read_bytes()[:4],
+                b"\x7fELF",
             )
+            # The codec libraries ffmpeg links against were carried into the
+            # bundle directory and the staging area was pruned.
+            bundle_lib = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+            self.assertEqual((bundle_lib / "libmp3lame.so.0").read_bytes(), b"lame")
+            self.assertEqual((bundle_lib / "libx264.so.164").read_bytes(), b"x264")
+            self.assertFalse((runtime / "lib" / ".system-libs").exists())
 
     def test_installs_verified_runtime_atomically(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_mediastorm_setup.py
+++ b/tests/test_mediastorm_setup.py
@@ -6,6 +6,8 @@ from unittest.mock import Mock, patch
 
 from utils import setup
 
+from tests.test_mediastorm_installer import _minimal_elf_bytes
+
 
 class MediaStormSetupTests(unittest.TestCase):
     def _runtime_tree(self, root: Path) -> None:
@@ -21,8 +23,12 @@ class MediaStormSetupTests(unittest.TestCase):
         (root / "python-venv" / "bin" / "python3").write_text(
             "python", encoding="utf-8"
         )
-        for binary_name in ("ffmpeg", "ffprobe", "yt-dlp", "deno"):
+        for binary_name in ("yt-dlp", "deno"):
             (root / "bin" / binary_name).write_text("binary", encoding="utf-8")
+        # ffmpeg/ffprobe must look like real ELF binaries: the runtime
+        # readiness check rejects unparseable seeds.
+        for binary_name in ("ffmpeg", "ffprobe"):
+            (root / "bin" / binary_name).write_bytes(_minimal_elf_bytes([]))
         for script_name in (
             "parse_title.py",
             "parse_title_batch.py",

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -464,17 +464,20 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
             sh_link = struct.unpack_from(endian + "I", block, 24)[0]
         sections.append((sh_type, sh_offset, sh_size, sh_link))
 
-    strtab_section = None
+    # DT_NEEDED strings resolve against the string table the SHT_DYNAMIC
+    # section links to (sh_link), so derive strtab from that link instead
+    # of SHT_DYNSYM's.
     dynamic_section = None
+    dynamic_sh_link = None
     for sh_type, sh_offset, sh_size, sh_link in sections:
-        if sh_type == 6:  # SHT_DYNAMIC
+        if sh_type == 6:  # SHT_DYNAMIC: sh_link points at its string table
             dynamic_section = (sh_offset, sh_size)
-        elif sh_type == 11:  # SHT_DYNSYM: sh_link points at the string table
-            if sh_link >= len(sections):
-                return None, []
-            strtab_section = sections[sh_link][1:3]
-    if strtab_section is None or dynamic_section is None:
+            dynamic_sh_link = sh_link
+    if dynamic_section is None:
         return None, []
+    if dynamic_sh_link >= len(sections):
+        return None, []
+    strtab_section = sections[dynamic_sh_link][1:3]
     strtab_offset, strtab_size = strtab_section
     try:
         with path.open("rb") as handle:

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -565,6 +565,18 @@ def _elf_dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
     return needed, (sonames[0] if sonames else None)
 
 
+def _is_leaf_library_name(name: str) -> bool:
+    """True when the name is a plain leaf library name.
+
+    Absolute paths, path components and traversal names must never be used
+    to construct paths into the staged library areas, so dependency names
+    parsed from ELF metadata pass this guard before any filesystem access.
+    """
+    return (
+        bool(name) and "/" not in name and "\\" not in name and name not in (".", "..")
+    )
+
+
 def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
     """Walk the DT_NEEDED graph of bin/ffmpeg and bin/ffprobe.
 
@@ -612,6 +624,9 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
         if soname in seen:
             continue
         seen.add(soname)
+        if not _is_leaf_library_name(soname):
+            missing.append(soname)
+            continue
         if soname in by_soname:
             queue.extend(dynamic_metadata(by_soname[soname])[0])
             continue

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -378,6 +378,49 @@ def mediastorm_runtime_matches_selection(
     return installed_selector.lower() == str(selector or "").strip().lower()
 
 
+# Bounds for the ELF section header table parse: real files carry only a
+# handful of sections, so cap the count and the table size before reading
+# malformed or hostile inputs.
+_MAX_ELF_SECTIONS = 4096
+_MAX_ELF_SECTION_TABLE_BYTES = 1 << 20
+
+
+def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
+    """Validate an ELF header and return its section table layout.
+
+    Returns (is64, endian, shoff, shentsize, shnum) for structurally valid
+    ELF files, or None for non-ELF, truncated or malformed input. The
+    section entry size must cover the sh_link read (offset 40 in the 64-bit
+    layout; 32-bit files keep their standard 40-byte minimum), and the
+    section count and table size are bounded before any allocation.
+    """
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(64)
+            if len(header) < 64 or header[:4] != b"\x7fELF":
+                return None
+            is64 = header[4] == 2
+            endian = "<" if header[5] == 1 else ">"
+            if is64:
+                shoff = struct.unpack_from(endian + "Q", header, 40)[0]
+                shentsize = struct.unpack_from(endian + "H", header, 58)[0]
+                shnum = struct.unpack_from(endian + "H", header, 60)[0]
+            else:
+                shoff = struct.unpack_from(endian + "I", header, 32)[0]
+                shentsize = struct.unpack_from(endian + "H", header, 46)[0]
+                shnum = struct.unpack_from(endian + "H", header, 48)[0]
+    except OSError:
+        return None
+    if (
+        shnum == 0
+        or shnum > _MAX_ELF_SECTIONS
+        or shentsize < (44 if is64 else 40)
+        or shentsize * shnum > _MAX_ELF_SECTION_TABLE_BYTES
+    ):
+        return None
+    return is64, endian, shoff, shentsize, shnum
+
+
 def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
     """Return (strtab bytes, dynamic entries) of an ELF file.
 
@@ -385,28 +428,16 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
     table are read (bounded pread calls), so probing large libraries is cheap.
     Non-ELF or malformed input yields (None, []).
     """
+    layout = _elf_header_layout(path)
+    if layout is None:
+        return None, []
+    is64, endian, shoff, shentsize, shnum = layout
+    entry_size = 16 if is64 else 8
     try:
         with path.open("rb") as handle:
-            header = handle.read(64)
-            if len(header) < 64 or header[:4] != b"\x7fELF":
-                return None, []
-            is64 = header[4] == 2
-            endian = "<" if header[5] == 1 else ">"
-            if is64:
-                shoff = struct.unpack_from(endian + "Q", header, 40)[0]
-                shentsize = struct.unpack_from(endian + "H", header, 58)[0]
-                shnum = struct.unpack_from(endian + "H", header, 60)[0]
-                entry_size = 16
-            else:
-                shoff = struct.unpack_from(endian + "I", header, 32)[0]
-                shentsize = struct.unpack_from(endian + "H", header, 46)[0]
-                shnum = struct.unpack_from(endian + "H", header, 48)[0]
-                entry_size = 8
             handle.seek(shoff)
             table = handle.read(shentsize * shnum)
     except OSError:
-        return None, []
-    if shentsize < 40 or shnum == 0:
         return None, []
     sections = []
     for index in range(shnum):
@@ -431,6 +462,8 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
         if sh_type == 6:  # SHT_DYNAMIC
             dynamic_section = (sh_offset, sh_size)
         elif sh_type == 11:  # SHT_DYNSYM: sh_link points at the string table
+            if sh_link >= len(sections):
+                return None, []
             strtab_section = sections[sh_link][1:3]
     if strtab_section is None or dynamic_section is None:
         return None, []
@@ -454,6 +487,26 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
     return strtab, entries
 
 
+def _elf_is_parseable(path: Path) -> bool:
+    """True when the file is a structurally complete ELF.
+
+    mediastorm_runtime_ready() uses this to reject runtimes whose
+    ffmpeg/ffprobe binaries are truncated or corrupt, while static binaries
+    (valid ELF files without a dynamic section) still pass.
+    """
+    layout = _elf_header_layout(path)
+    if layout is None:
+        return False
+    _is64, _endian, shoff, shentsize, shnum = layout
+    try:
+        with path.open("rb") as handle:
+            handle.seek(shoff)
+            table = handle.read(shentsize * shnum)
+    except OSError:
+        return False
+    return len(table) >= shentsize * shnum
+
+
 def _elf_string(entries: list[tuple[int, int]], strtab: bytes, tag: int) -> list[str]:
     values = []
     for d_tag, d_val in entries:
@@ -466,19 +519,88 @@ def _elf_string(entries: list[tuple[int, int]], strtab: bytes, tag: int) -> list
     return values
 
 
-def _elf_needed_libraries(path: Path) -> list[str]:
+def _elf_dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
+    """Return (DT_NEEDED libraries, DT_SONAME) of an ELF file.
+
+    Both values come from a single _elf_dynamic_info() parse, so callers
+    that need the dependency closure and the soname (bundle indexing,
+    closure walking) never parse the same file twice. Files without
+    dynamic information yield ([], None).
+    """
     strtab, entries = _elf_dynamic_info(path)
     if strtab is None:
-        return []
-    return _elf_string(entries, strtab, 1)  # DT_NEEDED
+        return [], None
+    needed = _elf_string(entries, strtab, 1)  # DT_NEEDED
+    sonames = _elf_string(entries, strtab, 14)  # DT_SONAME
+    return needed, (sonames[0] if sonames else None)
 
 
-def _elf_soname(path: Path) -> str | None:
-    strtab, entries = _elf_dynamic_info(path)
-    if strtab is None:
-        return None
-    values = _elf_string(entries, strtab, 14)  # DT_SONAME
-    return values[0] if values else None
+def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
+    """Walk the DT_NEEDED graph of bin/ffmpeg and bin/ffprobe.
+
+    Libraries are resolved against the staged bundle directory, the staged
+    system-library area and the core libraries every glibc host provides;
+    the sonames that remain unresolved are returned. When copy_missing is
+    set, each unresolved library found in the staging area is first copied
+    into the bundle directory (where LD_LIBRARY_PATH points); otherwise
+    the walk stays read-only. Staging-directory cleanup is left to the
+    caller.
+    """
+    bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+    staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
+    dynamic_cache: dict[Path, tuple[list[str], str | None]] = {}
+
+    def dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
+        resolved = path.resolve()
+        if resolved not in dynamic_cache:
+            dynamic_cache[resolved] = _elf_dynamic_metadata(resolved)
+        return dynamic_cache[resolved]
+
+    # Index the bundle by the soname each file declares and by its file
+    # name, so a dependency spelled either way (DT_NEEDED normally uses the
+    # SONAME, but libraries without one are referenced by filename) resolves
+    # to the same candidate. Symlinks are indexed by name only.
+    by_soname: dict[str, Path] = {}
+    if bundle_dir.is_dir():
+        for candidate in bundle_dir.iterdir():
+            if candidate.is_file():
+                if candidate.is_symlink():
+                    by_soname.setdefault(candidate.name, candidate)
+                else:
+                    _, soname = dynamic_metadata(candidate)
+                    by_soname.setdefault(candidate.name, candidate)
+                    if soname:
+                        by_soname.setdefault(soname, candidate)
+    queue = []
+    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
+        if seed.is_file():
+            queue.extend(dynamic_metadata(seed)[0])
+    missing = []
+    seen = set()
+    while queue:
+        soname = queue.pop()
+        if soname in seen:
+            continue
+        seen.add(soname)
+        if soname in by_soname:
+            queue.extend(dynamic_metadata(by_soname[soname])[0])
+            continue
+        if soname in _CORE_HOST_LIBRARIES:
+            continue
+        staged = staging_dir / soname
+        if staging_dir.is_dir() and (staged.is_file() or staged.is_symlink()):
+            resolved = staged.resolve()
+            if resolved.is_file():
+                if copy_missing:
+                    destination = bundle_dir / soname
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    if destination.exists() or destination.is_symlink():
+                        _remove_existing(destination)
+                    shutil.copy2(resolved, destination)
+                queue.extend(dynamic_metadata(resolved)[0])
+                continue
+        missing.append(soname)
+    return missing
 
 
 def _runtime_missing_libraries(runtime: Path) -> list[str]:
@@ -488,42 +610,7 @@ def _runtime_missing_libraries(runtime: Path) -> list[str]:
     bundle directory, the staged system-library area and the core libraries
     every glibc host provides. Returns the sonames that remain unresolved.
     """
-    bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
-    staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
-    by_soname: dict[str, Path] = {}
-    if bundle_dir.is_dir():
-        for candidate in bundle_dir.iterdir():
-            if candidate.is_file():
-                if candidate.is_symlink():
-                    by_soname.setdefault(candidate.name, candidate)
-                else:
-                    by_soname.setdefault(
-                        _elf_soname(candidate) or candidate.name, candidate
-                    )
-    queue = []
-    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
-        if seed.is_file():
-            queue.extend(_elf_needed_libraries(seed))
-    missing = []
-    seen = set()
-    while queue:
-        soname = queue.pop()
-        if soname in seen:
-            continue
-        seen.add(soname)
-        if soname in by_soname:
-            queue.extend(_elf_needed_libraries(by_soname[soname]))
-            continue
-        if soname in _CORE_HOST_LIBRARIES:
-            continue
-        staged = staging_dir / soname
-        if staged.is_file() or staged.is_symlink():
-            resolved = staged.resolve()
-            if resolved.is_file():
-                queue.extend(_elf_needed_libraries(resolved))
-                continue
-        missing.append(soname)
-    return missing
+    return _walk_runtime_closure(runtime, copy_missing=False)
 
 
 def _resolve_runtime_libraries(runtime: Path) -> list[str]:
@@ -534,49 +621,42 @@ def _resolve_runtime_libraries(runtime: Path) -> list[str]:
     staging area. Returns the sonames that could not be resolved; callers
     should treat any entry as a hard install failure.
     """
+    missing = _walk_runtime_closure(runtime, copy_missing=True)
     staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
-    bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
-    by_soname: dict[str, Path] = {}
-    if bundle_dir.is_dir():
-        for candidate in bundle_dir.iterdir():
-            if candidate.is_file():
-                if candidate.is_symlink():
-                    by_soname.setdefault(candidate.name, candidate)
-                else:
-                    by_soname.setdefault(
-                        _elf_soname(candidate) or candidate.name, candidate
-                    )
-    queue = []
-    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
-        if seed.is_file():
-            queue.extend(_elf_needed_libraries(seed))
-    missing = []
-    seen = set()
-    while queue:
-        soname = queue.pop()
-        if soname in seen:
-            continue
-        seen.add(soname)
-        if soname in by_soname:
-            queue.extend(_elf_needed_libraries(by_soname[soname]))
-            continue
-        if soname in _CORE_HOST_LIBRARIES:
-            continue
-        staged = staging_dir / soname
-        if staging_dir.is_dir() and (staged.is_file() or staged.is_symlink()):
-            resolved = staged.resolve()
-            if resolved.is_file():
-                destination = bundle_dir / soname
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                if destination.exists() or destination.is_symlink():
-                    _remove_existing(destination)
-                shutil.copy2(resolved, destination)
-                queue.extend(_elf_needed_libraries(resolved))
-                continue
-        missing.append(soname)
     if staging_dir.is_dir():
         _remove_existing(staging_dir)
     return missing
+
+
+# The sonames the host dynamic loader can satisfy (from `ldconfig -p`),
+# probed once on first use. None means "not probed yet".
+_HOST_LOADER_LIBRARIES: frozenset[str] | None = None
+
+
+def _host_loader_provides(soname: str) -> bool:
+    """True when the host dynamic loader can satisfy the soname.
+
+    Consults `ldconfig -p` (the loader cache the dynamic linker uses) once
+    and remembers the result. Hosts without ldconfig, or where the query
+    fails, are treated as providing nothing, so an unknown environment
+    never masks a missing library.
+    """
+    global _HOST_LOADER_LIBRARIES
+    if _HOST_LOADER_LIBRARIES is None:
+        names = []
+        try:
+            result = subprocess.run(
+                ["ldconfig", "-p"], capture_output=True, text=True, timeout=10
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        else:
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if " => " in line:
+                        names.append(line.split()[0])
+        _HOST_LOADER_LIBRARIES = frozenset(names)
+    return soname in _HOST_LOADER_LIBRARIES
 
 
 def mediastorm_runtime_ready(runtime_dir: str | Path) -> bool:
@@ -593,11 +673,28 @@ def mediastorm_runtime_ready(runtime_dir: str | Path) -> bool:
     )
     if not all(path.is_file() for path in required):
         return False
+    # A truncated or corrupt ffmpeg/ffprobe cannot be validated and would
+    # not run; treat the runtime as not ready instead of assuming an
+    # empty dependency closure.
+    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
+        if not _elf_is_parseable(seed):
+            logger.warning("mediastorm runtime binary is not a parseable ELF: %s", seed)
+            return False
     # The runtime is only usable when every library ffmpeg/ffprobe link
-    # against resolves inside the staged runtime (or is a core glibc
-    # library). Runtimes staged before the codec libraries were carried
-    # fail this check and are reinstalled by the update manager.
-    return not _runtime_missing_libraries(runtime)
+    # against resolves inside the staged runtime, is a core glibc library,
+    # or is provided by the host loader. Runtimes staged before the codec
+    # libraries were carried fail this check and are reinstalled by the
+    # update manager.
+    missing = _runtime_missing_libraries(runtime)
+    unresolved = [name for name in missing if not _host_loader_provides(name)]
+    if unresolved:
+        logger.warning(
+            "mediastorm runtime is missing libraries the host loader "
+            "cannot provide: %s",
+            ", ".join(sorted(unresolved)),
+        )
+        return False
+    return True
 
 
 def mediastorm_target_status(

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -389,10 +389,13 @@ def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
     """Validate an ELF header and return its section table layout.
 
     Returns (is64, endian, shoff, shentsize, shnum) for structurally valid
-    ELF files, or None for non-ELF, truncated or malformed input. The
-    section entry size must cover the sh_link read (offset 40 in the 64-bit
-    layout; 32-bit files keep their standard 40-byte minimum), and the
-    section count and table size are bounded before any allocation.
+    ELF files, or None for non-ELF, truncated or malformed input. A missing
+    section table (e_shoff == 0 with e_shnum == 0) is accepted as valid for
+    static binaries; ELF header validation stays independent of program- and
+    section-header presence. When a table is present, the section entry size
+    must cover the sh_link read (offset 40 in the 64-bit layout; 32-bit files
+    keep their standard 40-byte minimum), and the section count and table
+    size are bounded before any allocation.
     """
     try:
         with path.open("rb") as handle:
@@ -411,6 +414,11 @@ def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
                 shnum = struct.unpack_from(endian + "H", header, 48)[0]
     except OSError:
         return None
+    if shoff == 0 and shnum == 0:
+        # No section header table at all: valid for static binaries. The
+        # dynamic-metadata callers treat this as "no sections" and report
+        # no DT_NEEDED entries, so such files stay usable.
+        return is64, endian, shoff, shentsize, shnum
     if (
         shnum == 0
         or shnum > _MAX_ELF_SECTIONS

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -383,6 +383,10 @@ def mediastorm_runtime_matches_selection(
 # malformed or hostile inputs.
 _MAX_ELF_SECTIONS = 4096
 _MAX_ELF_SECTION_TABLE_BYTES = 1 << 20
+# Individual reads of the dynamic section and its string table are capped
+# too (real files carry only a few KB there), so corrupt section sizes can
+# never trigger excessive allocation.
+_MAX_ELF_DYNAMIC_READ_BYTES = 1 << 20
 
 
 def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
@@ -433,8 +437,9 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
     """Return (strtab bytes, dynamic entries) of an ELF file.
 
     Only the ELF header, section header table, dynamic section and its string
-    table are read (bounded pread calls), so probing large libraries is cheap.
-    Non-ELF or malformed input yields (None, []).
+    table are read (offset/size validated against the file length and capped),
+    so probing large libraries is cheap. Non-ELF or malformed input yields
+    (None, []).
     """
     layout = _elf_header_layout(path)
     if layout is None:
@@ -479,12 +484,26 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
         return None, []
     strtab_section = sections[dynamic_sh_link][1:3]
     strtab_offset, strtab_size = strtab_section
+    dynamic_offset, dynamic_size = dynamic_section
     try:
         with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            file_size = handle.tell()
+            # Validate every offset/size against the real file length and
+            # cap the reads, so corrupt section headers cannot force huge
+            # allocations; invalid or oversized sections simply yield no
+            # dynamic metadata.
+            if not (
+                strtab_offset + strtab_size <= file_size
+                and strtab_size <= _MAX_ELF_DYNAMIC_READ_BYTES
+                and dynamic_offset + dynamic_size <= file_size
+                and dynamic_size <= _MAX_ELF_DYNAMIC_READ_BYTES
+            ):
+                return None, []
             handle.seek(strtab_offset)
             strtab = handle.read(strtab_size)
-            handle.seek(dynamic_section[0])
-            dynamic_data = handle.read(dynamic_section[1])
+            handle.seek(dynamic_offset)
+            dynamic_data = handle.read(dynamic_size)
     except OSError:
         return None, []
     entries = []

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -594,6 +594,7 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
     """
     bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
     staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
+    staging_root = staging_dir.resolve()
     dynamic_cache: dict[Path, tuple[list[str], str | None]] = {}
 
     def dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
@@ -638,8 +639,18 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
             continue
         staged = staging_dir / soname
         if staging_dir.is_dir() and (staged.is_file() or staged.is_symlink()):
-            resolved = staged.resolve()
-            if resolved.is_file():
+            try:
+                resolved = staged.resolve()
+            except (OSError, RuntimeError):
+                resolved = None
+            # Constrain symlink targets to the staging root: a staged link
+            # may only point at a file inside lib/.system-libs, never at an
+            # absolute or traversal target elsewhere.
+            if (
+                resolved is not None
+                and resolved.is_file()
+                and resolved.is_relative_to(staging_root)
+            ):
                 if copy_missing:
                     destination = bundle_dir / soname
                     destination.parent.mkdir(parents=True, exist_ok=True)

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -437,17 +437,21 @@ def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
     return is64, endian, shoff, shentsize, shnum
 
 
-def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
-    """Return (strtab bytes, dynamic entries) of an ELF file.
+def _elf_dynamic_info(
+    path: Path,
+) -> tuple[bytes | None, list[tuple[int, int]], bool]:
+    """Return (strtab bytes, dynamic entries, invalid flag) of an ELF file.
 
     Only the ELF header, section header table, dynamic section and its string
     table are read (offset/size validated against the file length and capped),
-    so probing large libraries is cheap. Non-ELF or malformed input yields
-    (None, []).
+    so probing large libraries is cheap. invalid=True means the file is not a
+    parseable ELF or its dynamic metadata is malformed/out of bounds;
+    invalid=False with strtab=None means the file is a valid ELF without a
+    dynamic section (static binary).
     """
     layout = _elf_header_layout(path)
     if layout is None:
-        return None, []
+        return None, [], True
     is64, endian, shoff, shentsize, shnum = layout
     entry_size = 16 if is64 else 8
     try:
@@ -455,13 +459,13 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
             handle.seek(shoff)
             table = handle.read(shentsize * shnum)
     except OSError:
-        return None, []
+        return None, [], True
     sections = []
     for index in range(shnum):
         offset = index * shentsize
         block = table[offset : offset + shentsize]
         if len(block) < shentsize:
-            return None, []
+            return None, [], True
         sh_type = struct.unpack_from(endian + "I", block, 4)[0]
         if is64:
             sh_offset = struct.unpack_from(endian + "Q", block, 24)[0]
@@ -483,9 +487,10 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
             dynamic_section = (sh_offset, sh_size)
             dynamic_sh_link = sh_link
     if dynamic_section is None:
-        return None, []
+        # Valid ELF without dynamic information: a static binary.
+        return None, [], False
     if dynamic_sh_link >= len(sections):
-        return None, []
+        return None, [], True
     strtab_section = sections[dynamic_sh_link][1:3]
     strtab_offset, strtab_size = strtab_section
     dynamic_offset, dynamic_size = dynamic_section
@@ -495,21 +500,21 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
             file_size = handle.tell()
             # Validate every offset/size against the real file length and
             # cap the reads, so corrupt section headers cannot force huge
-            # allocations; invalid or oversized sections simply yield no
-            # dynamic metadata.
+            # allocations; invalid or oversized sections are rejected as
+            # invalid dynamic metadata.
             if not (
                 strtab_offset + strtab_size <= file_size
                 and strtab_size <= _MAX_ELF_DYNAMIC_READ_BYTES
                 and dynamic_offset + dynamic_size <= file_size
                 and dynamic_size <= _MAX_ELF_DYNAMIC_READ_BYTES
             ):
-                return None, []
+                return None, [], True
             handle.seek(strtab_offset)
             strtab = handle.read(strtab_size)
             handle.seek(dynamic_offset)
             dynamic_data = handle.read(dynamic_size)
     except OSError:
-        return None, []
+        return None, [], True
     entries = []
     for offset in range(0, len(dynamic_data) - entry_size + 1, entry_size):
         d_tag, d_val = struct.unpack_from(
@@ -518,27 +523,7 @@ def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
         entries.append((d_tag, d_val))
         if d_tag == 0:
             break
-    return strtab, entries
-
-
-def _elf_is_parseable(path: Path) -> bool:
-    """True when the file is a structurally complete ELF.
-
-    mediastorm_runtime_ready() uses this to reject runtimes whose
-    ffmpeg/ffprobe binaries are truncated or corrupt, while static binaries
-    (valid ELF files without a dynamic section) still pass.
-    """
-    layout = _elf_header_layout(path)
-    if layout is None:
-        return False
-    _is64, _endian, shoff, shentsize, shnum = layout
-    try:
-        with path.open("rb") as handle:
-            handle.seek(shoff)
-            table = handle.read(shentsize * shnum)
-    except OSError:
-        return False
-    return len(table) >= shentsize * shnum
+    return strtab, entries, False
 
 
 def _elf_string(entries: list[tuple[int, int]], strtab: bytes, tag: int) -> list[str]:
@@ -553,15 +538,19 @@ def _elf_string(entries: list[tuple[int, int]], strtab: bytes, tag: int) -> list
     return values
 
 
-def _elf_dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
+def _elf_dynamic_metadata(path: Path) -> tuple[list[str] | None, str | None]:
     """Return (DT_NEEDED libraries, DT_SONAME) of an ELF file.
 
     Both values come from a single _elf_dynamic_info() parse, so callers
     that need the dependency closure and the soname (bundle indexing,
     closure walking) never parse the same file twice. Files without
-    dynamic information yield ([], None).
+    dynamic information, including valid static binaries, yield ([], None);
+    malformed or out-of-bounds dynamic metadata yields (None, None) so
+    callers can reject the file instead of assuming an empty closure.
     """
-    strtab, entries = _elf_dynamic_info(path)
+    strtab, entries, invalid = _elf_dynamic_info(path)
+    if invalid:
+        return None, None
     if strtab is None:
         return [], None
     needed = _elf_string(entries, strtab, 1)  # DT_NEEDED
@@ -586,18 +575,20 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
 
     Libraries are resolved against the staged bundle directory, the staged
     system-library area and the core libraries every glibc host provides;
-    the sonames that remain unresolved are returned. When copy_missing is
-    set, each unresolved library found in the staging area is first copied
-    into the bundle directory (where LD_LIBRARY_PATH points); otherwise
-    the walk stays read-only. Staging-directory cleanup is left to the
-    caller.
+    the sonames that remain unresolved are returned. Files whose dynamic
+    metadata is malformed or out of bounds are rejected instead of trusted:
+    bundle candidates are not indexed and staged candidates are left
+    unresolved. When copy_missing is set, each unresolved library found in
+    the staging area is first copied into the bundle directory (where
+    LD_LIBRARY_PATH points); otherwise the walk stays read-only.
+    Staging-directory cleanup is left to the caller.
     """
     bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
     staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
     staging_root = staging_dir.resolve()
-    dynamic_cache: dict[Path, tuple[list[str], str | None]] = {}
+    dynamic_cache: dict[Path, tuple[list[str] | None, str | None]] = {}
 
-    def dynamic_metadata(path: Path) -> tuple[list[str], str | None]:
+    def dynamic_metadata(path: Path) -> tuple[list[str] | None, str | None]:
         resolved = path.resolve()
         if resolved not in dynamic_cache:
             dynamic_cache[resolved] = _elf_dynamic_metadata(resolved)
@@ -614,14 +605,20 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
                 if candidate.is_symlink():
                     by_soname.setdefault(candidate.name, candidate)
                 else:
-                    _, soname = dynamic_metadata(candidate)
+                    needed, soname = dynamic_metadata(candidate)
+                    if needed is None:
+                        # Reject files whose dynamic metadata cannot be
+                        # parsed instead of indexing them.
+                        continue
                     by_soname.setdefault(candidate.name, candidate)
                     if soname:
                         by_soname.setdefault(soname, candidate)
     queue = []
     for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
         if seed.is_file():
-            queue.extend(dynamic_metadata(seed)[0])
+            needed, _soname = dynamic_metadata(seed)
+            if needed is not None:
+                queue.extend(needed)
     missing = []
     seen = set()
     while queue:
@@ -633,7 +630,11 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
             missing.append(soname)
             continue
         if soname in by_soname:
-            queue.extend(dynamic_metadata(by_soname[soname])[0])
+            needed, _soname = dynamic_metadata(by_soname[soname])
+            if needed is None:
+                missing.append(soname)
+            else:
+                queue.extend(needed)
             continue
         if soname in _CORE_HOST_LIBRARIES:
             continue
@@ -651,13 +652,17 @@ def _walk_runtime_closure(runtime: Path, *, copy_missing: bool) -> list[str]:
                 and resolved.is_file()
                 and resolved.is_relative_to(staging_root)
             ):
+                needed, _soname = dynamic_metadata(resolved)
+                if needed is None:
+                    missing.append(soname)
+                    continue
                 if copy_missing:
                     destination = bundle_dir / soname
                     destination.parent.mkdir(parents=True, exist_ok=True)
                     if destination.exists() or destination.is_symlink():
                         _remove_existing(destination)
                     shutil.copy2(resolved, destination)
-                queue.extend(dynamic_metadata(resolved)[0])
+                queue.extend(needed)
                 continue
         missing.append(soname)
     return missing
@@ -733,12 +738,16 @@ def mediastorm_runtime_ready(runtime_dir: str | Path) -> bool:
     )
     if not all(path.is_file() for path in required):
         return False
-    # A truncated or corrupt ffmpeg/ffprobe cannot be validated and would
-    # not run; treat the runtime as not ready instead of assuming an
-    # empty dependency closure.
+    # A truncated, corrupt or out-of-bounds-dynamic ffmpeg/ffprobe cannot
+    # be validated and would not run; treat the runtime as not ready
+    # instead of assuming an empty dependency closure. Valid static
+    # binaries (no dynamic section) still pass.
     for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
-        if not _elf_is_parseable(seed):
-            logger.warning("mediastorm runtime binary is not a parseable ELF: %s", seed)
+        needed, _soname = _elf_dynamic_metadata(seed)
+        if needed is None:
+            logger.warning(
+                "mediastorm runtime binary has invalid dynamic metadata: %s", seed
+            )
             return False
     # The runtime is only usable when every library ffmpeg/ffprobe link
     # against resolves inside the staged runtime, is a core glibc library,

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -2,6 +2,7 @@ import os
 import posixpath
 import re
 import shutil
+import struct
 import subprocess
 import tarfile
 import tempfile
@@ -51,6 +52,36 @@ _SOURCE_DIRECTORIES = {
     "usr/lib/jellyfin-ffmpeg": "lib/jellyfin-ffmpeg",
 }
 
+# The jellyfin-ffmpeg binaries also link against codec and support libraries
+# that the image installs as system libraries under /usr/lib/<multiarch>
+# (mp3lame, opus, vorbis, theora, x264/x265, bluray, OpenCL, and their
+# transitive dependencies). Those packages are not guaranteed on the DUMB
+# host, so every entry under that multiarch tree is staged into
+# lib/.system-libs during layer application. Once all layers are applied,
+# _resolve_runtime_libraries() reads the DT_NEEDED graph of the extracted
+# ffmpeg/ffprobe and carries exactly the missing libraries into the bundle
+# directory where LD_LIBRARY_PATH already points, then discards the staging
+# area. This keeps the runtime self-contained and stays correct when
+# upstream images bump SONAMEs or change the codec set.
+_SYSTEM_LIB_STAGING_DIR = "lib/.system-libs"
+
+# Libraries every glibc-based DUMB host guarantees; the runtime never needs
+# to carry them. If a future image requires anything else from the host,
+# the install fails loudly listing the missing libraries.
+_CORE_HOST_LIBRARIES = frozenset(
+    {
+        "libc.so.6",
+        "libm.so.6",
+        "libpthread.so.0",
+        "libdl.so.2",
+        "librt.so.1",
+        "ld-linux-x86-64.so.2",
+        "ld-linux-aarch64.so.1",
+        "libgcc_s.so.1",
+        "libstdc++.so.6",
+    }
+)
+
 
 class MediaStormInstallError(RuntimeError):
     pass
@@ -75,6 +106,12 @@ def _mapped_path(source_path: str) -> str | None:
         prefix = f"{source_dir}/"
         if source_path.startswith(prefix):
             return f"{target_dir}/{source_path[len(prefix):]}"
+    parent, _, name = source_path.rpartition("/")
+    if parent.startswith("usr/lib/") and parent.endswith("-linux-gnu"):
+        # System libraries of the image's base distribution are staged
+        # separately and pruned after the runtime library closure resolves
+        # which ones ffmpeg/ffprobe actually need.
+        return f"{_SYSTEM_LIB_STAGING_DIR}/{name}"
     return None
 
 
@@ -341,6 +378,207 @@ def mediastorm_runtime_matches_selection(
     return installed_selector.lower() == str(selector or "").strip().lower()
 
 
+def _elf_dynamic_info(path: Path) -> tuple[bytes | None, list[tuple[int, int]]]:
+    """Return (strtab bytes, dynamic entries) of an ELF file.
+
+    Only the ELF header, section header table, dynamic section and its string
+    table are read (bounded pread calls), so probing large libraries is cheap.
+    Non-ELF or malformed input yields (None, []).
+    """
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(64)
+            if len(header) < 64 or header[:4] != b"\x7fELF":
+                return None, []
+            is64 = header[4] == 2
+            endian = "<" if header[5] == 1 else ">"
+            if is64:
+                shoff = struct.unpack_from(endian + "Q", header, 40)[0]
+                shentsize = struct.unpack_from(endian + "H", header, 58)[0]
+                shnum = struct.unpack_from(endian + "H", header, 60)[0]
+                entry_size = 16
+            else:
+                shoff = struct.unpack_from(endian + "I", header, 32)[0]
+                shentsize = struct.unpack_from(endian + "H", header, 46)[0]
+                shnum = struct.unpack_from(endian + "H", header, 48)[0]
+                entry_size = 8
+            handle.seek(shoff)
+            table = handle.read(shentsize * shnum)
+    except OSError:
+        return None, []
+    if shentsize < 40 or shnum == 0:
+        return None, []
+    sections = []
+    for index in range(shnum):
+        offset = index * shentsize
+        block = table[offset : offset + shentsize]
+        if len(block) < shentsize:
+            return None, []
+        sh_type = struct.unpack_from(endian + "I", block, 4)[0]
+        if is64:
+            sh_offset = struct.unpack_from(endian + "Q", block, 24)[0]
+            sh_size = struct.unpack_from(endian + "Q", block, 32)[0]
+            sh_link = struct.unpack_from(endian + "I", block, 40)[0]
+        else:
+            sh_offset = struct.unpack_from(endian + "I", block, 16)[0]
+            sh_size = struct.unpack_from(endian + "I", block, 20)[0]
+            sh_link = struct.unpack_from(endian + "I", block, 24)[0]
+        sections.append((sh_type, sh_offset, sh_size, sh_link))
+
+    strtab_section = None
+    dynamic_section = None
+    for sh_type, sh_offset, sh_size, sh_link in sections:
+        if sh_type == 6:  # SHT_DYNAMIC
+            dynamic_section = (sh_offset, sh_size)
+        elif sh_type == 11:  # SHT_DYNSYM: sh_link points at the string table
+            strtab_section = sections[sh_link][1:3]
+    if strtab_section is None or dynamic_section is None:
+        return None, []
+    strtab_offset, strtab_size = strtab_section
+    try:
+        with path.open("rb") as handle:
+            handle.seek(strtab_offset)
+            strtab = handle.read(strtab_size)
+            handle.seek(dynamic_section[0])
+            dynamic_data = handle.read(dynamic_section[1])
+    except OSError:
+        return None, []
+    entries = []
+    for offset in range(0, len(dynamic_data) - entry_size + 1, entry_size):
+        d_tag, d_val = struct.unpack_from(
+            endian + ("qQ" if is64 else "iI"), dynamic_data, offset
+        )
+        entries.append((d_tag, d_val))
+        if d_tag == 0:
+            break
+    return strtab, entries
+
+
+def _elf_string(entries: list[tuple[int, int]], strtab: bytes, tag: int) -> list[str]:
+    values = []
+    for d_tag, d_val in entries:
+        if d_tag == tag:
+            end = strtab.find(b"\x00", d_val)
+            if d_val < len(strtab) and end != -1:
+                values.append(strtab[d_val:end].decode("utf-8", "replace"))
+        elif d_tag == 0:
+            break
+    return values
+
+
+def _elf_needed_libraries(path: Path) -> list[str]:
+    strtab, entries = _elf_dynamic_info(path)
+    if strtab is None:
+        return []
+    return _elf_string(entries, strtab, 1)  # DT_NEEDED
+
+
+def _elf_soname(path: Path) -> str | None:
+    strtab, entries = _elf_dynamic_info(path)
+    if strtab is None:
+        return None
+    values = _elf_string(entries, strtab, 14)  # DT_SONAME
+    return values[0] if values else None
+
+
+def _runtime_missing_libraries(runtime: Path) -> list[str]:
+    """Libraries the staged runtime links against that it cannot provide.
+
+    Walks the DT_NEEDED graph of bin/ffmpeg and bin/ffprobe over the staged
+    bundle directory, the staged system-library area and the core libraries
+    every glibc host provides. Returns the sonames that remain unresolved.
+    """
+    bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+    staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
+    by_soname: dict[str, Path] = {}
+    if bundle_dir.is_dir():
+        for candidate in bundle_dir.iterdir():
+            if candidate.is_file():
+                if candidate.is_symlink():
+                    by_soname.setdefault(candidate.name, candidate)
+                else:
+                    by_soname.setdefault(
+                        _elf_soname(candidate) or candidate.name, candidate
+                    )
+    queue = []
+    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
+        if seed.is_file():
+            queue.extend(_elf_needed_libraries(seed))
+    missing = []
+    seen = set()
+    while queue:
+        soname = queue.pop()
+        if soname in seen:
+            continue
+        seen.add(soname)
+        if soname in by_soname:
+            queue.extend(_elf_needed_libraries(by_soname[soname]))
+            continue
+        if soname in _CORE_HOST_LIBRARIES:
+            continue
+        staged = staging_dir / soname
+        if staged.is_file() or staged.is_symlink():
+            resolved = staged.resolve()
+            if resolved.is_file():
+                queue.extend(_elf_needed_libraries(resolved))
+                continue
+        missing.append(soname)
+    return missing
+
+
+def _resolve_runtime_libraries(runtime: Path) -> list[str]:
+    """Carry the system libraries ffmpeg/ffprobe need into the bundle dir.
+
+    Copies each unresolved library from the staged system-library area into
+    lib/jellyfin-ffmpeg/lib (where LD_LIBRARY_PATH points), then discards the
+    staging area. Returns the sonames that could not be resolved; callers
+    should treat any entry as a hard install failure.
+    """
+    staging_dir = runtime / _SYSTEM_LIB_STAGING_DIR
+    bundle_dir = runtime / "lib" / "jellyfin-ffmpeg" / "lib"
+    by_soname: dict[str, Path] = {}
+    if bundle_dir.is_dir():
+        for candidate in bundle_dir.iterdir():
+            if candidate.is_file():
+                if candidate.is_symlink():
+                    by_soname.setdefault(candidate.name, candidate)
+                else:
+                    by_soname.setdefault(
+                        _elf_soname(candidate) or candidate.name, candidate
+                    )
+    queue = []
+    for seed in (runtime / "bin" / "ffmpeg", runtime / "bin" / "ffprobe"):
+        if seed.is_file():
+            queue.extend(_elf_needed_libraries(seed))
+    missing = []
+    seen = set()
+    while queue:
+        soname = queue.pop()
+        if soname in seen:
+            continue
+        seen.add(soname)
+        if soname in by_soname:
+            queue.extend(_elf_needed_libraries(by_soname[soname]))
+            continue
+        if soname in _CORE_HOST_LIBRARIES:
+            continue
+        staged = staging_dir / soname
+        if staging_dir.is_dir() and (staged.is_file() or staged.is_symlink()):
+            resolved = staged.resolve()
+            if resolved.is_file():
+                destination = bundle_dir / soname
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if destination.exists() or destination.is_symlink():
+                    _remove_existing(destination)
+                shutil.copy2(resolved, destination)
+                queue.extend(_elf_needed_libraries(resolved))
+                continue
+        missing.append(soname)
+    if staging_dir.is_dir():
+        _remove_existing(staging_dir)
+    return missing
+
+
 def mediastorm_runtime_ready(runtime_dir: str | Path) -> bool:
     runtime = Path(runtime_dir)
     required = (
@@ -353,7 +591,13 @@ def mediastorm_runtime_ready(runtime_dir: str | Path) -> bool:
         runtime / "bin" / "yt-dlp",
         runtime / "bin" / "deno",
     )
-    return all(path.is_file() for path in required)
+    if not all(path.is_file() for path in required):
+        return False
+    # The runtime is only usable when every library ffmpeg/ffprobe link
+    # against resolves inside the staged runtime (or is a core glibc
+    # library). Runtimes staged before the codec libraries were carried
+    # fail this check and are reinstalled by the update manager.
+    return not _runtime_missing_libraries(runtime)
 
 
 def mediastorm_target_status(
@@ -520,6 +764,14 @@ def install_mediastorm_runtime(
                 raise MediaStormInstallError(str(exc)) from exc
             finally:
                 layer_path.unlink(missing_ok=True)
+
+        missing_libraries = _resolve_runtime_libraries(staged_runtime)
+        if missing_libraries:
+            raise MediaStormInstallError(
+                "Downloaded mediastorm OCI runtime links against system "
+                "libraries that are neither bundled nor available on this "
+                "host: " + ", ".join(sorted(set(missing_libraries)))
+            )
 
         upstream_version_path = staged_runtime / "app-version.txt"
         try:

--- a/utils/mediastorm_installer.py
+++ b/utils/mediastorm_installer.py
@@ -393,18 +393,22 @@ def _elf_header_layout(path: Path) -> tuple[bool, str, int, int, int] | None:
     """Validate an ELF header and return its section table layout.
 
     Returns (is64, endian, shoff, shentsize, shnum) for structurally valid
-    ELF files, or None for non-ELF, truncated or malformed input. A missing
-    section table (e_shoff == 0 with e_shnum == 0) is accepted as valid for
-    static binaries; ELF header validation stays independent of program- and
-    section-header presence. When a table is present, the section entry size
-    must cover the sh_link read (offset 40 in the 64-bit layout; 32-bit files
-    keep their standard 40-byte minimum), and the section count and table
-    size are bounded before any allocation.
+    ELF files, or None for non-ELF, truncated or malformed input. EI_CLASS
+    must be 1 (32-bit) or 2 (64-bit) and EI_DATA 1 (little-endian) or 2
+    (big-endian); a missing section table (e_shoff == 0 with e_shnum == 0)
+    is accepted as valid for static binaries, and ELF header validation
+    stays independent of program- and section-header presence. When a table
+    is present, the section entry size must cover the sh_link read (offset
+    40 in the 64-bit layout; 32-bit files keep their standard 40-byte
+    minimum), and the section count and table size are bounded before any
+    allocation.
     """
     try:
         with path.open("rb") as handle:
             header = handle.read(64)
             if len(header) < 64 or header[:4] != b"\x7fELF":
+                return None
+            if header[4] not in (1, 2) or header[5] not in (1, 2):
                 return None
             is64 = header[4] == 2
             endian = "<" if header[5] == 1 else ">"


### PR DESCRIPTION
### Mediastorm install woes (part deux)

mediastorm installs successfully but **ffmpeg/ffprobe fail at runtime**. The service and web UI come up, but player apps can't start any playback, and the server fails to read potential streams when preparing.

The jellyfin-ffmpeg binaries are not completely self-contained. They link against codec/support libraries (`libmp3lame.so.0`, `libopus.so.0`, `libvorbis`, etc.) that the image installs as *system* packages under `/usr/lib/<multiarch>`. DUMB doesn't use the whole image, and doesn't have these libs in its own Ubuntu base.

### Changes (`utils/mediastorm_installer.py`)

- **Stage** every entry under the image's `usr/lib/<multiarch>` tree into `lib/.system-libs/` during layer application.
- **Resolve dynamically** (`_resolve_runtime_libraries`): after all layers are applied, a parser walks the `DT_NEEDED` graph and copies exactly the unresolved libraries into the bundle directory where `LD_LIBRARY_PATH` already points. Then it prunes the staging area.
- **Fix for the future: fail loudly**: if a future image links against a library it doesn't ship (outside the core glibc set), the install aborts listing the missing sonames. That guards against silent failures for this in the future.
- **Closure-based readiness**: `mediastorm_runtime_ready` now verifies the library closure, so runtimes staged before this fix are flagged and reinstalled automatically by the update manager, and stale runtimes can't report healthy. Static-binary layouts (arm64 images) have no dependencies and are unaffected.

### Test updates (`tests/test_mediastorm_installer.py`)

Added a minimal ELF64 builder so tests exercise the `DT_NEEDED` parsing. There's a new test asserting that installs fail loudly for unknown libraries.

### Deployment note

Affected users need to update, then reinstall/update mediastorm once (the closure readiness check flags existing broken runtimes, so the manager should pick it up automatically).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically discovers and bundles required FFmpeg and FFprobe runtime libraries, including transitive dependencies.
  * Supports dependency resolution across multiarchitecture system libraries.
  * Validates runtime binaries and their complete dependency closure before installation.

* **Bug Fixes**
  * Installations now fail clearly when required, malformed, or unresolved libraries are encountered.
  * Static binaries are handled correctly.
  * Unsafe staged library links are rejected.
  * Temporary library staging is cleaned up after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->